### PR TITLE
Phase 0: Vitest setup and safety-net tests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -37,7 +37,8 @@
         "gh-pages": "^6.1.1",
         "tsx": "^4.7.0",
         "typescript": "^5.3.3",
-        "vite": "^5.0.8"
+        "vite": "^5.0.8",
+        "vitest": "^4.1.0"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -332,6 +333,40 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@emnapi/core": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.9.0.tgz",
+      "integrity": "sha512-0DQ98G9ZQZOxfUcQn1waV2yS8aWdZ6kJMbYCJB3oUBecjWYO1fqJ+a1DRfPF3O5JEkwqwP1A9QEN/9mYm2Yd0w==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.0",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.9.0.tgz",
+      "integrity": "sha512-QN75eB0IH2ywSpRpNddCRfQIhmJYBCJ1x5Lb3IscKAL8bMnVAKnRg8dCoXbHzVLLH7P38N2Z3mtulB7W0J0FKw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.0.tgz",
+      "integrity": "sha512-N10dEJNSsUx41Z6pZsXU8FjPjpBEplgH24sfkmITrBED1/U2Esum9F3lfLrMjKHHjmi557zQn7kR9R+XWXu5Rg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
       }
     },
     "node_modules/@emotion/is-prop-valid": {
@@ -847,6 +882,23 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.1.tgz",
+      "integrity": "sha512-p64ah1M1ld8xjWv3qbvFwHiFVWrq1yFvV4f7w+mzaqiR4IlSgkqhcRdHwsGgomwzBH51sRY4NEowLxnaBjcW/A==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1",
+        "@tybys/wasm-util": "^0.10.1"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -883,6 +935,16 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/@oxc-project/types": {
+      "version": "0.120.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.120.0.tgz",
+      "integrity": "sha512-k1YNu55DuvAip/MGE1FTsIuU3FUCn6v/ujG9V7Nq5Df/kX2CWb13hhwD0lmJGMGqE+bE1MXvv9SZVnMzEXlWcg==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
       }
     },
     "node_modules/@parcel/watcher": {
@@ -1376,6 +1438,261 @@
         }
       }
     },
+    "node_modules/@rolldown/binding-android-arm64": {
+      "version": "1.0.0-rc.10",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0-rc.10.tgz",
+      "integrity": "sha512-jOHxwXhxmFKuXztiu1ORieJeTbx5vrTkcOkkkn2d35726+iwhrY1w/+nYY/AGgF12thg33qC3R1LMBF5tHTZHg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-arm64": {
+      "version": "1.0.0-rc.10",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.0-rc.10.tgz",
+      "integrity": "sha512-gED05Teg/vtTZbIJBc4VNMAxAFDUPkuO/rAIyyxZjTj1a1/s6z5TII/5yMGZ0uLRCifEtwUQn8OlYzuYc0m70w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-x64": {
+      "version": "1.0.0-rc.10",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.0-rc.10.tgz",
+      "integrity": "sha512-rI15NcM1mA48lqrIxVkHfAqcyFLcQwyXWThy+BQ5+mkKKPvSO26ir+ZDp36AgYoYVkqvMcdS8zOE6SeBsR9e8A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-freebsd-x64": {
+      "version": "1.0.0-rc.10",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.0-rc.10.tgz",
+      "integrity": "sha512-XZRXHdTa+4ME1MuDVp021+doQ+z6Ei4CCFmNc5/sKbqb8YmkiJdj8QKlV3rCI0AJtAeSB5n0WGPuJWNL9p/L2w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
+      "version": "1.0.0-rc.10",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.0-rc.10.tgz",
+      "integrity": "sha512-R0SQMRluISSLzFE20sPWYHVmJdDQnRyc/FzSCN72BqQmh2SOZUFG+N3/vBZpR4C6WpEUVYJLrYUXaj43sJsNLA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-gnu": {
+      "version": "1.0.0-rc.10",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.0-rc.10.tgz",
+      "integrity": "sha512-Y1reMrV/o+cwpduYhJuOE3OMKx32RMYCidf14y+HssARRmhDuWXJ4yVguDg2R/8SyyGNo+auzz64LnPK9Hq6jg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-musl": {
+      "version": "1.0.0-rc.10",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.0-rc.10.tgz",
+      "integrity": "sha512-vELN+HNb2IzuzSBUOD4NHmP9yrGwl1DVM29wlQvx1OLSclL0NgVWnVDKl/8tEks79EFek/kebQKnNJkIAA4W2g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-ppc64-gnu": {
+      "version": "1.0.0-rc.10",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.0-rc.10.tgz",
+      "integrity": "sha512-ZqrufYTgzxbHwpqOjzSsb0UV/aV2TFIY5rP8HdsiPTv/CuAgCRjM6s9cYFwQ4CNH+hf9Y4erHW1GjZuZ7WoI7w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-s390x-gnu": {
+      "version": "1.0.0-rc.10",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.0-rc.10.tgz",
+      "integrity": "sha512-gSlmVS1FZJSRicA6IyjoRoKAFK7IIHBs7xJuHRSmjImqk3mPPWbR7RhbnfH2G6bcmMEllCt2vQ/7u9e6bBnByg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-gnu": {
+      "version": "1.0.0-rc.10",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.0-rc.10.tgz",
+      "integrity": "sha512-eOCKUpluKgfObT2pHjztnaWEIbUabWzk3qPZ5PuacuPmr4+JtQG4k2vGTY0H15edaTnicgU428XW/IH6AimcQw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-musl": {
+      "version": "1.0.0-rc.10",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.0-rc.10.tgz",
+      "integrity": "sha512-Xdf2jQbfQowJnLcgYfD/m0Uu0Qj5OdxKallD78/IPPfzaiaI4KRAwZzHcKQ4ig1gtg1SuzC7jovNiM2TzQsBXA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-openharmony-arm64": {
+      "version": "1.0.0-rc.10",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.0-rc.10.tgz",
+      "integrity": "sha512-o1hYe8hLi1EY6jgPFyxQgQ1wcycX+qz8eEbVmot2hFkgUzPxy9+kF0u0NIQBeDq+Mko47AkaFFaChcvZa9UX9Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi": {
+      "version": "1.0.0-rc.10",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.0-rc.10.tgz",
+      "integrity": "sha512-Ugv9o7qYJudqQO5Y5y2N2SOo6S4WiqiNOpuQyoPInnhVzCY+wi/GHltcLHypG9DEUYMB0iTB/huJrpadiAcNcA==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@napi-rs/wasm-runtime": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-arm64-msvc": {
+      "version": "1.0.0-rc.10",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.0-rc.10.tgz",
+      "integrity": "sha512-7UODQb4fQUNT/vmgDZBl3XOBAIOutP5R3O/rkxg0aLfEGQ4opbCgU5vOw/scPe4xOqBwL9fw7/RP1vAMZ6QlAQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-x64-msvc": {
+      "version": "1.0.0-rc.10",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.0-rc.10.tgz",
+      "integrity": "sha512-PYxKHMVHOb5NJuDL53vBUl1VwUjymDcYI6rzpIni0C9+9mTiJedvUxSk7/RPp7OOAm3v+EjgMu9bIy3N6b408w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
     "node_modules/@rolldown/pluginutils": {
       "version": "1.0.0-beta.27",
       "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-beta.27.tgz",
@@ -1733,6 +2050,24 @@
         "win32"
       ]
     },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tybys/wasm-util": {
+      "version": "0.10.1",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
+      "integrity": "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
@@ -1777,6 +2112,24 @@
       "dependencies": {
         "@babel/types": "^7.3.0"
       }
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/estree": {
       "version": "1.0.8",
@@ -1907,6 +2260,119 @@
         "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
       }
     },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.0.tgz",
+      "integrity": "sha512-EIxG7k4wlWweuCLG9Y5InKFwpMEOyrMb6ZJ1ihYu02LVj/bzUwn2VMU+13PinsjRW75XnITeFrQBMH5+dLvCDA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.0",
+        "@vitest/utils": "4.1.0",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.0.tgz",
+      "integrity": "sha512-evxREh+Hork43+Y4IOhTo+h5lGmVRyjqI739Rz4RlUPqwrkFFDF6EMvOOYjTx4E8Tl6gyCLRL8Mu7Ry12a13Tw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.0",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.0.tgz",
+      "integrity": "sha512-3RZLZlh88Ib0J7NQTRATfc/3ZPOnSUn2uDBUoGNn5T36+bALixmzphN26OUD3LRXWkJu4H0s5vvUeqBiw+kS0A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.0.tgz",
+      "integrity": "sha512-Duvx2OzQ7d6OjchL+trw+aSrb9idh7pnNfxrklo14p3zmNL4qPCDeIJAK+eBKYjkIwG96Bc6vYuxhqDXQOWpoQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.0",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.0.tgz",
+      "integrity": "sha512-0Vy9euT1kgsnj1CHttwi9i9o+4rRLEaPRSOJ5gyv579GJkNpgJK+B4HSv/rAWixx2wdAFci1X4CEPjiu2bXIMg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.0",
+        "@vitest/utils": "4.1.0",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.0.tgz",
+      "integrity": "sha512-pz77k+PgNpyMDv2FV6qmk5ZVau6c3R8HC8v342T2xlFxQKTrSeYw9waIJG8KgV9fFwAtTu4ceRzMivPTH6wSxw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.0.tgz",
+      "integrity": "sha512-XfPXT6a8TZY3dcGY8EdwsBulFCIw+BeeX0RZn2x/BtiY/75YGh8FeWGG8QISN/WhaqSrE2OrlDgtF8q5uhOTmw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.0",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
     "node_modules/array-union": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
@@ -1915,6 +2381,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/async": {
@@ -2013,6 +2489,16 @@
         }
       ],
       "license": "CC-BY-4.0"
+    },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/chokidar": {
       "version": "4.0.3",
@@ -2132,8 +2618,8 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
       "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "devOptional": true,
       "license": "Apache-2.0",
-      "optional": true,
       "engines": {
         "node": ">=8"
       }
@@ -2173,6 +2659,13 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/email-addresses/-/email-addresses-5.0.0.tgz",
       "integrity": "sha512-4OIPYlA6JXqtVn8zpHpGiI7vE6EQOAg16aGnDMIAlZVinnoZ8208tW1hAbjWydgN/4PLTT9q+O1K6AH/vALJGw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/es-module-lexer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.0.0.tgz",
+      "integrity": "sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==",
       "dev": true,
       "license": "MIT"
     },
@@ -2238,6 +2731,26 @@
         "node": ">=0.8.0"
       }
     },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -2269,6 +2782,24 @@
       "license": "ISC",
       "dependencies": {
         "reusify": "^1.0.4"
+      }
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
       }
     },
     "node_modules/filename-reserved-regex": {
@@ -2574,6 +3105,267 @@
         "graceful-fs": "^4.1.6"
       }
     },
+    "node_modules/lightningcss": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
+      "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "detect-libc": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "optionalDependencies": {
+        "lightningcss-android-arm64": "1.32.0",
+        "lightningcss-darwin-arm64": "1.32.0",
+        "lightningcss-darwin-x64": "1.32.0",
+        "lightningcss-freebsd-x64": "1.32.0",
+        "lightningcss-linux-arm-gnueabihf": "1.32.0",
+        "lightningcss-linux-arm64-gnu": "1.32.0",
+        "lightningcss-linux-arm64-musl": "1.32.0",
+        "lightningcss-linux-x64-gnu": "1.32.0",
+        "lightningcss-linux-x64-musl": "1.32.0",
+        "lightningcss-win32-arm64-msvc": "1.32.0",
+        "lightningcss-win32-x64-msvc": "1.32.0"
+      }
+    },
+    "node_modules/lightningcss-android-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz",
+      "integrity": "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.32.0.tgz",
+      "integrity": "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz",
+      "integrity": "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-freebsd-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.32.0.tgz",
+      "integrity": "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm-gnueabihf": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.32.0.tgz",
+      "integrity": "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.32.0.tgz",
+      "integrity": "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.32.0.tgz",
+      "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.32.0.tgz",
+      "integrity": "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.32.0.tgz",
+      "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-arm64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.32.0.tgz",
+      "integrity": "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-x64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.32.0.tgz",
+      "integrity": "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
     "node_modules/locate-path": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
@@ -2613,6 +3405,16 @@
       "license": "ISC",
       "dependencies": {
         "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
       }
     },
     "node_modules/make-dir": {
@@ -2703,6 +3505,17 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/obug": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.1.tgz",
+      "integrity": "sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT"
+    },
     "node_modules/p-limit": {
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.2.tgz",
@@ -2761,6 +3574,13 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
@@ -3174,6 +3994,47 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/rolldown": {
+      "version": "1.0.0-rc.10",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.0-rc.10.tgz",
+      "integrity": "sha512-q7j6vvarRFmKpgJUT8HCAUljkgzEp4LAhPlJUvQhA5LA1SUL36s5QCysMutErzL3EbNOZOkoziSx9iZC4FddKA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@oxc-project/types": "=0.120.0",
+        "@rolldown/pluginutils": "1.0.0-rc.10"
+      },
+      "bin": {
+        "rolldown": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "optionalDependencies": {
+        "@rolldown/binding-android-arm64": "1.0.0-rc.10",
+        "@rolldown/binding-darwin-arm64": "1.0.0-rc.10",
+        "@rolldown/binding-darwin-x64": "1.0.0-rc.10",
+        "@rolldown/binding-freebsd-x64": "1.0.0-rc.10",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.0.0-rc.10",
+        "@rolldown/binding-linux-arm64-gnu": "1.0.0-rc.10",
+        "@rolldown/binding-linux-arm64-musl": "1.0.0-rc.10",
+        "@rolldown/binding-linux-ppc64-gnu": "1.0.0-rc.10",
+        "@rolldown/binding-linux-s390x-gnu": "1.0.0-rc.10",
+        "@rolldown/binding-linux-x64-gnu": "1.0.0-rc.10",
+        "@rolldown/binding-linux-x64-musl": "1.0.0-rc.10",
+        "@rolldown/binding-openharmony-arm64": "1.0.0-rc.10",
+        "@rolldown/binding-wasm32-wasi": "1.0.0-rc.10",
+        "@rolldown/binding-win32-arm64-msvc": "1.0.0-rc.10",
+        "@rolldown/binding-win32-x64-msvc": "1.0.0-rc.10"
+      }
+    },
+    "node_modules/rolldown/node_modules/@rolldown/pluginutils": {
+      "version": "1.0.0-rc.10",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.10.tgz",
+      "integrity": "sha512-UkVDEFk1w3mveXeKgaTuYfKWtPbvgck1dT8TUG3bnccrH0XtLTuAyfCoks4Q/M5ZGToSVJTIQYCzy2g/atAOeg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/rollup": {
       "version": "4.59.0",
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.59.0.tgz",
@@ -3288,6 +4149,13 @@
       "integrity": "sha512-y0m1JoUZSlPAjXVtPPW70aZWfIL/dSP7AFkRnniLCrK/8MDKog3TySTBmckD+RObVxH0v4Tox67+F14PdED2oQ==",
       "license": "MIT"
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/slash": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
@@ -3306,6 +4174,20 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.0.0.tgz",
+      "integrity": "sha512-zUMPtQ/HBY3/50VbpkupYHbRroTRZJPRLvreamgErJVys0ceuzMkD44J/QjqhHjOzK42GQ3QZIeFG1OYfOtKqQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/strip-outer": {
       "version": "1.0.1",
@@ -3358,6 +4240,63 @@
       "resolved": "https://registry.npmjs.org/stylis/-/stylis-4.3.6.tgz",
       "integrity": "sha512-yQ3rwFWRfwNUY7H5vpU0wfdkNSnvnJinhF9830Swlaxl03zsOjCfmX0ugac+3LtK0lYSgwL/KXc8oYL3mG4YFQ==",
       "license": "MIT"
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.0.4.tgz",
+      "integrity": "sha512-u9r3uZC0bdpGOXtlxUIdwf9pkmvhqJdrVCH9fapQtgy/OeTTMZ1nqH7agtvEfmGui6e1XxjcdrlxvxJvc3sMqw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.15",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
+      "integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyglobby/node_modules/picomatch": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
+      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
     },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
@@ -3970,6 +4909,225 @@
         "@esbuild/win32-arm64": "0.21.5",
         "@esbuild/win32-ia32": "0.21.5",
         "@esbuild/win32-x64": "0.21.5"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.0.tgz",
+      "integrity": "sha512-YbDrMF9jM2Lqc++2530UourxZHmkKLxrs4+mYhEwqWS97WJ7wOYEkcr+QfRgJ3PW9wz3odRijLZjHEaRLTNbqw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.0",
+        "@vitest/mocker": "4.1.0",
+        "@vitest/pretty-format": "4.1.0",
+        "@vitest/runner": "4.1.0",
+        "@vitest/snapshot": "4.1.0",
+        "@vitest/spy": "4.1.0",
+        "@vitest/utils": "4.1.0",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.0.3",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0-0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.0",
+        "@vitest/browser-preview": "4.1.0",
+        "@vitest/browser-webdriverio": "4.1.0",
+        "@vitest/ui": "4.1.0",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/picomatch": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
+      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/vitest/node_modules/postcss": {
+      "version": "8.5.8",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.8.tgz",
+      "integrity": "sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.11",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/vitest/node_modules/vite": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.1.tgz",
+      "integrity": "sha512-wt+Z2qIhfFt85uiyRt5LPU4oVEJBXj8hZNWKeqFG4gRG/0RaRGJ7njQCwzFVjO+v4+Ipmf5CY7VdmZRAYYBPHw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lightningcss": "^1.32.0",
+        "picomatch": "^4.0.3",
+        "postcss": "^8.5.8",
+        "rolldown": "1.0.0-rc.10",
+        "tinyglobby": "^0.2.15"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "@vitejs/devtools": "^0.1.0",
+        "esbuild": "^0.27.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "@vitejs/devtools": {
+          "optional": true
+        },
+        "esbuild": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/yallist": {

--- a/package.json
+++ b/package.json
@@ -28,6 +28,8 @@
     "dev": "vite",
     "build": "tsc && vite build",
     "preview": "vite preview",
+    "test": "vitest run",
+    "test:watch": "vitest",
     "type-check": "tsc --noEmit",
     "run-ts": "tsx",
     "generateCppFiles": "npm run run-ts utils/cppMidiGenerator/cppMidiConfigGenerator.ts",
@@ -63,6 +65,7 @@
     "gh-pages": "^6.1.1",
     "tsx": "^4.7.0",
     "typescript": "^5.3.3",
-    "vite": "^5.0.8"
+    "vite": "^5.0.8",
+    "vitest": "^4.1.0"
   }
 }

--- a/src/__tests__/midi/midiMappers.test.ts
+++ b/src/__tests__/midi/midiMappers.test.ts
@@ -1,0 +1,168 @@
+import { describe, it, expect } from 'vitest'
+
+// We test the mapper logic directly by reimplementing the pure math from commonMidiApi.
+// This captures the contracts without needing Redux imports.
+
+describe('MIDI value mappers (contract tests)', () => {
+
+    describe('CC mapper (7-bit)', () => {
+        const ccToValue = (midiValue: number, bipolar: boolean) =>
+            bipolar ? (midiValue - 64) / 127 : midiValue / 127
+
+        const valueToCc = (value: number, bipolar: boolean) =>
+            bipolar ? Math.floor(63 * value + 64) : Math.floor(127 * value)
+
+        it('unipolar: 0 -> 0, 127 -> 1', () => {
+            expect(ccToValue(0, false)).toBeCloseTo(0, 5)
+            expect(ccToValue(127, false)).toBeCloseTo(1, 5)
+        })
+
+        it('unipolar: round-trips within 1 step', () => {
+            for (const value of [0, 0.25, 0.5, 0.75, 1]) {
+                const midi = valueToCc(value, false)
+                const recovered = ccToValue(midi, false)
+                expect(recovered).toBeCloseTo(value, 1)
+            }
+        })
+
+        it('bipolar: 64 -> 0, 0 -> ~-0.5, 127 -> ~0.5', () => {
+            expect(ccToValue(64, true)).toBeCloseTo(0, 2)
+            expect(ccToValue(0, true)).toBeLessThan(0)
+            expect(ccToValue(127, true)).toBeGreaterThan(0)
+        })
+
+        it('bipolar: encodes with 63-range, decodes with 127-range (known asymmetry)', () => {
+            // The bipolar CC mapper uses asymmetric encoding:
+            //   encode: floor(63 * value + 64)  — maps [-1,1] to [1,127]
+            //   decode: (midi - 64) / 127        — maps [0,127] to [-0.504, 0.496]
+            // This means the output range is actually ~[-0.5, 0.5] not [-1, 1].
+            // Round-trip is only accurate near 0.
+            const midi0 = valueToCc(0, true)
+            expect(ccToValue(midi0, true)).toBeCloseTo(0, 1)
+
+            // Verify the asymmetry exists and is consistent
+            const midiNeg = valueToCc(-0.5, true)
+            const recoveredNeg = ccToValue(midiNeg, true)
+            expect(recoveredNeg).toBeLessThan(0)
+
+            const midiPos = valueToCc(0.5, true)
+            const recoveredPos = ccToValue(midiPos, true)
+            expect(recoveredPos).toBeGreaterThan(0)
+        })
+    })
+
+    describe('NRPN mapper (16-bit + 5-bit valueIndex)', () => {
+        const nrpnToValue = (midiValue: number, bipolar: boolean) => {
+            const valuePart = midiValue & 0xFFFF
+            const valueIndex = midiValue >> 16
+            const value = bipolar ? (valuePart - 32767) / 32767 : valuePart / 65535
+            return { value, valueIndex }
+        }
+
+        const valueToNrpn = (value: number, bipolar: boolean, valueIndex?: number) => {
+            let midiValue = bipolar
+                ? Math.floor(32767 * value + 32767)
+                : Math.floor(65535 * value)
+            if (valueIndex !== undefined && valueIndex >= 0 && valueIndex < 32) {
+                midiValue += (valueIndex << 16)
+            }
+            return midiValue
+        }
+
+        it('unipolar: 0 -> 0, 65535 -> 1', () => {
+            expect(nrpnToValue(0, false).value).toBeCloseTo(0, 5)
+            expect(nrpnToValue(65535, false).value).toBeCloseTo(1, 3)
+        })
+
+        it('bipolar: 32767 -> 0, 0 -> -1, 65534 -> ~1', () => {
+            expect(nrpnToValue(32767, true).value).toBeCloseTo(0, 3)
+            expect(nrpnToValue(0, true).value).toBeCloseTo(-1, 3)
+            expect(nrpnToValue(65534, true).value).toBeCloseTo(1, 3)
+        })
+
+        it('round-trips unipolar values', () => {
+            for (const value of [0, 0.25, 0.5, 0.75, 1]) {
+                const midi = valueToNrpn(value, false)
+                const recovered = nrpnToValue(midi, false)
+                expect(recovered.value).toBeCloseTo(value, 3)
+            }
+        })
+
+        it('round-trips bipolar values', () => {
+            for (const value of [-1, -0.5, 0, 0.5, 1]) {
+                const midi = valueToNrpn(value, true)
+                const recovered = nrpnToValue(midi, true)
+                expect(recovered.value).toBeCloseTo(value, 3)
+            }
+        })
+
+        it('encodes valueIndex in upper bits', () => {
+            const midi = valueToNrpn(0.5, false, 7)
+            const result = nrpnToValue(midi, false)
+            expect(result.valueIndex).toBe(7)
+            expect(result.value).toBeCloseTo(0.5, 3)
+        })
+
+        it('preserves valueIndex through round-trip', () => {
+            for (let vi = 0; vi < 32; vi++) {
+                const midi = valueToNrpn(0.5, false, vi)
+                const result = nrpnToValue(midi, false)
+                expect(result.valueIndex).toBe(vi)
+            }
+        })
+    })
+
+    describe('NRPN send/receive byte splitting', () => {
+        // Mirrors the encoding in midibus nrpn.send and decoding in receiveMidiMessage
+        const encode = (value: number) => ({
+            loValue: value & 0b01111111,
+            midValue: (value >> 7) & 0b01111111,
+            hiValue: (value >> 14) & 0b01111111,
+        })
+
+        const decodeCorrected = (lo: number, mid: number, hi: number) =>
+            (hi << 14) + (mid << 7) + lo
+
+        // This is the CURRENT (buggy) decode in midibus.ts line 287
+        const decodeBuggy = (lo: number, mid: number, _hi: number) =>
+            (mid << 14) + (mid << 7) + lo
+
+        it('encode/decode round-trips correctly with fixed decode', () => {
+            for (const value of [0, 127, 128, 16383, 16384, 65535, 2097151]) {
+                const { loValue, midValue, hiValue } = encode(value)
+                expect(decodeCorrected(loValue, midValue, hiValue)).toBe(value)
+            }
+        })
+
+        it('buggy decode fails for values > 16383 (confirms the bug)', () => {
+            // For values that need hiValue, the buggy version gives wrong results
+            const value = 16384 // Needs hiValue = 1, midValue = 0, loValue = 0
+            const { loValue, midValue, hiValue } = encode(value)
+            expect(hiValue).toBe(1)
+            expect(decodeBuggy(loValue, midValue, hiValue)).not.toBe(value)
+        })
+
+        it('buggy decode only works for values where midValue is 0 (values <= 127)', () => {
+            // The bug uses midValue in place of hiValue: (mid << 14) + (mid << 7) + lo
+            // This only matches correct decode when midValue is 0 (i.e., value <= 127)
+            for (const value of [0, 64, 127]) {
+                const { loValue, midValue, hiValue } = encode(value)
+                expect(hiValue).toBe(0)
+                expect(midValue).toBe(0)
+                expect(decodeBuggy(loValue, midValue, hiValue)).toBe(
+                    decodeCorrected(loValue, midValue, hiValue)
+                )
+            }
+        })
+
+        it('buggy decode fails for values 128-16383 (midValue > 0, hiValue = 0)', () => {
+            const value = 128 // midValue = 1, loValue = 1
+            const { loValue, midValue, hiValue } = encode(value)
+            expect(hiValue).toBe(0)
+            expect(midValue).toBe(1)
+            // Buggy: (1 << 14) + (1 << 7) + 1 = 16512, correct: (0 << 14) + (1 << 7) + 1 = 128
+            expect(decodeBuggy(loValue, midValue, hiValue)).not.toBe(value)
+            expect(decodeCorrected(loValue, midValue, hiValue)).toBe(value)
+        })
+    })
+})

--- a/src/__tests__/midi/serializer.test.ts
+++ b/src/__tests__/midi/serializer.test.ts
@@ -1,0 +1,105 @@
+import { describe, it, expect } from 'vitest'
+import {
+    splitTo7,
+    splitInt8To7,
+    splitInt16To7,
+    getBoolArray,
+} from '../../midi/rpc/serializer'
+
+describe('serializer', () => {
+
+    describe('splitTo7', () => {
+        it('splits a 7-bit value into 1 byte', () => {
+            expect(splitTo7(0, 7)).toEqual([0])
+            expect(splitTo7(127, 7)).toEqual([127])
+            expect(splitTo7(64, 7)).toEqual([64])
+        })
+
+        it('splits an 8-bit value into 2 bytes (MSB first)', () => {
+            // 255 = 0b11111111 -> [0b1, 0b1111111] = [1, 127]
+            expect(splitTo7(255, 8)).toEqual([1, 127])
+            expect(splitTo7(0, 8)).toEqual([0, 0])
+            expect(splitTo7(128, 8)).toEqual([1, 0])
+        })
+
+        it('splits a 14-bit value into 2 bytes', () => {
+            // 16383 = 0x3FFF -> [127, 127]
+            expect(splitTo7(16383, 14)).toEqual([127, 127])
+            expect(splitTo7(0, 14)).toEqual([0, 0])
+            // 128 = 0b10000000 -> [1, 0]
+            expect(splitTo7(128, 14)).toEqual([1, 0])
+        })
+
+        it('splits a 16-bit value into 3 bytes', () => {
+            expect(splitTo7(0, 16)).toEqual([0, 0, 0])
+            // 65535 = 0xFFFF -> [3, 127, 127]
+            expect(splitTo7(65535, 16)).toEqual([3, 127, 127])
+        })
+
+        it('splits a 21-bit value into 3 bytes', () => {
+            expect(splitTo7(0, 21)).toEqual([0, 0, 0])
+            // 2097151 = 0x1FFFFF -> [127, 127, 127]
+            expect(splitTo7(2097151, 21)).toEqual([127, 127, 127])
+        })
+
+        it('splits a 32-bit value into 5 bytes', () => {
+            expect(splitTo7(0, 32)).toEqual([0, 0, 0, 0, 0])
+        })
+
+        it('masks off bits beyond the specified width', () => {
+            // Value 256 in 7 bits should be masked to 0 (256 & 127 = 0)
+            // But splitTo7 logs a warning and masks
+            const result = splitTo7(256, 7)
+            expect(result).toEqual([0])
+        })
+    })
+
+    describe('splitInt8To7', () => {
+        it('handles positive values', () => {
+            expect(splitInt8To7(0)).toEqual([0, 0])
+            expect(splitInt8To7(127)).toEqual([0, 127])
+            expect(splitInt8To7(1)).toEqual([0, 1])
+        })
+
+        it('handles negative values (two\'s complement)', () => {
+            // -1 as uint8 = 255 = 0b11111111 -> [1, 127]
+            expect(splitInt8To7(-1)).toEqual([1, 127])
+            // -128 as uint8 = 128 = 0b10000000 -> [1, 0]
+            expect(splitInt8To7(-128)).toEqual([1, 0])
+        })
+
+        it('clamps to int8 range', () => {
+            expect(splitInt8To7(200)).toEqual(splitInt8To7(127))
+            expect(splitInt8To7(-200)).toEqual(splitInt8To7(-128))
+        })
+    })
+
+    describe('splitInt16To7', () => {
+        it('handles positive values', () => {
+            expect(splitInt16To7(0)).toEqual([0, 0, 0])
+            expect(splitInt16To7(1)).toEqual([0, 0, 1])
+            expect(splitInt16To7(32767)).toEqual([1, 127, 127])
+        })
+
+        it('handles negative values (two\'s complement)', () => {
+            // -1 as uint16 = 65535 = 0xFFFF -> [3, 127, 127]
+            expect(splitInt16To7(-1)).toEqual([3, 127, 127])
+            // -32768 as uint16 = 32768 = 0x8000 -> [2, 0, 0]
+            expect(splitInt16To7(-32768)).toEqual([2, 0, 0])
+        })
+
+        it('clamps to int16 range', () => {
+            expect(splitInt16To7(40000)).toEqual(splitInt16To7(32767))
+            expect(splitInt16To7(-40000)).toEqual(splitInt16To7(-32768))
+        })
+    })
+
+    describe('getBoolArray', () => {
+        it('returns [1] for true', () => {
+            expect(getBoolArray(true)).toEqual([1])
+        })
+        it('returns [0] for false', () => {
+            expect(getBoolArray(false)).toEqual([0])
+        })
+    })
+})

--- a/src/__tests__/midi/slopeCalculator.test.ts
+++ b/src/__tests__/midi/slopeCalculator.test.ts
@@ -1,0 +1,181 @@
+import { describe, it, expect } from 'vitest'
+import {
+    getLinearToDBMapper,
+    getLinearToExpMapper,
+    getLinearToExpBipolarMapper,
+    getMapperWithFade,
+    inverse,
+    isZero,
+} from '../../midi/slopeCalculator'
+
+describe('slopeCalculator', () => {
+
+    describe('isZero', () => {
+        it('returns true for 0', () => {
+            expect(isZero(0)).toBe(true)
+        })
+        it('returns true for values within epsilon', () => {
+            expect(isZero(0.0005)).toBe(true)
+            expect(isZero(-0.0005)).toBe(true)
+        })
+        it('returns false for values outside epsilon', () => {
+            expect(isZero(0.01)).toBe(false)
+            expect(isZero(-0.01)).toBe(false)
+        })
+    })
+
+    describe('getLinearToDBMapper', () => {
+        it('rising curve: maps inputMax to outputMax', () => {
+            const mapper = getLinearToDBMapper(1, 1, 23, true, false)
+            expect(mapper(1)).toBeCloseTo(1, 5)
+        })
+
+        it('rising curve: maps 0 to a small but nonzero value (no stretch)', () => {
+            const mapper = getLinearToDBMapper(1, 1, 23, true, false)
+            const val = mapper(0)
+            expect(val).toBeGreaterThan(0)
+            expect(val).toBeLessThan(0.1)
+        })
+
+        it('rising curve with stretchY: maps 0 to 0', () => {
+            const mapper = getLinearToDBMapper(1, 1, 23, true, true)
+            expect(mapper(0)).toBeCloseTo(0, 5)
+        })
+
+        it('rising curve with stretchY: maps inputMax to outputMax', () => {
+            const mapper = getLinearToDBMapper(1, 1, 23, true, true)
+            expect(mapper(1)).toBeCloseTo(1, 5)
+        })
+
+        it('falling curve: maps 0 to outputMax', () => {
+            const mapper = getLinearToDBMapper(1, 1, 23, false, false)
+            expect(mapper(0)).toBeCloseTo(1, 5)
+        })
+
+        it('is monotonically increasing for rising curve', () => {
+            const mapper = getLinearToDBMapper(1, 1, 23, true, false)
+            let prev = mapper(0)
+            for (let i = 0.01; i <= 1; i += 0.01) {
+                const curr = mapper(i)
+                expect(curr).toBeGreaterThanOrEqual(prev)
+                prev = curr
+            }
+        })
+
+        it('scales with outputMax', () => {
+            const mapper = getLinearToDBMapper(1, 2, 23, true, false)
+            expect(mapper(1)).toBeCloseTo(2, 5)
+        })
+    })
+
+    describe('getLinearToExpMapper', () => {
+        it('maps 0 to 0', () => {
+            const mapper = getLinearToExpMapper(1, 1, 3.5)
+            expect(mapper(0)).toBeCloseTo(0, 3)
+        })
+
+        it('maps maxInput to outputRange', () => {
+            const mapper = getLinearToExpMapper(1, 1, 3.5)
+            expect(mapper(1)).toBeCloseTo(1, 3)
+        })
+
+        it('is monotonically increasing', () => {
+            const mapper = getLinearToExpMapper(1, 1, 3.5)
+            let prev = mapper(0)
+            for (let i = 0.01; i <= 1; i += 0.01) {
+                const curr = mapper(i)
+                expect(curr).toBeGreaterThanOrEqual(prev)
+                prev = curr
+            }
+        })
+
+        it('falls back to linear when steepness is ~0', () => {
+            const mapper = getLinearToExpMapper(1, 1, 0)
+            expect(mapper(0.5)).toBeCloseTo(0.5, 3)
+            expect(mapper(0.25)).toBeCloseTo(0.25, 3)
+        })
+
+        it('positive steepness gives slow start, fast end', () => {
+            const mapper = getLinearToExpMapper(1, 1, 3.5)
+            // At midpoint input, output should be less than midpoint (slow start)
+            expect(mapper(0.5)).toBeLessThan(0.5)
+        })
+
+        it('negative steepness gives fast start, slow end', () => {
+            const mapper = getLinearToExpMapper(1, 1, -3.5)
+            // At midpoint input, output should be more than midpoint (fast start)
+            expect(mapper(0.5)).toBeGreaterThan(0.5)
+        })
+    })
+
+    describe('getLinearToExpBipolarMapper', () => {
+        it('maps 0 to outputMin', () => {
+            const mapper = getLinearToExpBipolarMapper(1, -100, 200, 2)
+            expect(mapper(0)).toBeCloseTo(-100, 1)
+        })
+
+        it('maps maxInput to outputMin + outputRange', () => {
+            const mapper = getLinearToExpBipolarMapper(1, -100, 200, 2)
+            expect(mapper(1)).toBeCloseTo(100, 1)
+        })
+    })
+
+    describe('getMapperWithFade', () => {
+        it('applies linear fade at the start for rising curves', () => {
+            const base = getLinearToDBMapper(1, 1, 23, true, false)
+            const faded = getMapperWithFade(base, 1, true, 0.01)
+
+            // At 0 the fade should give 0
+            expect(faded(0)).toBeCloseTo(0, 5)
+
+            // Just past the fade region, should match the base function
+            expect(faded(0.02)).toBeCloseTo(base(0.02), 3)
+        })
+
+        it('passes through unchanged outside fade region', () => {
+            const base = getLinearToExpMapper(1, 1, 3.5)
+            const faded = getMapperWithFade(base, 1, true, 0.01)
+
+            expect(faded(0.5)).toBeCloseTo(base(0.5), 5)
+            expect(faded(1)).toBeCloseTo(base(1), 5)
+        })
+    })
+
+    describe('inverse', () => {
+        it('inverts a linear function', () => {
+            const linear = (x: number) => x
+            const inv = inverse(linear, 65534)
+            expect(inv(0.5)).toBeCloseTo(0.5, 3)
+            expect(inv(0)).toBeCloseTo(0, 3)
+            expect(inv(1)).toBeCloseTo(1, 3)
+        })
+
+        it('inverts an exponential mapper', () => {
+            const exp = getLinearToExpMapper(1, 1, 3.5)
+            const inv = inverse(exp, 65534)
+
+            // Round-trip: inv(exp(x)) should equal x
+            for (const x of [0, 0.1, 0.25, 0.5, 0.75, 1]) {
+                const mapped = exp(x)
+                const recovered = inv(mapped)
+                expect(recovered).toBeCloseTo(x, 3)
+            }
+        })
+
+        it('inverts a dB mapper with fade', () => {
+            const base = getMapperWithFade(
+                getLinearToDBMapper(1, 1, 23, true, false),
+                1,
+                true,
+                10 / 65534,
+            )
+            const inv = inverse(base, 65534)
+
+            for (const x of [0.1, 0.25, 0.5, 0.75, 1]) {
+                const mapped = base(x)
+                const recovered = inv(mapped)
+                expect(recovered).toBeCloseTo(x, 2)
+            }
+        })
+    })
+})

--- a/src/__tests__/synthcore/responseMappers.test.ts
+++ b/src/__tests__/synthcore/responseMappers.test.ts
@@ -1,0 +1,136 @@
+import { describe, it, expect } from 'vitest'
+import {
+    dbLevelResponseMapper,
+    timeResponseMapper,
+    uniBipolarLevelResponseMapper,
+} from '../../synthcore/modules/common/responseMappers'
+
+describe('responseMappers', () => {
+
+    describe('dbLevelResponseMapper', () => {
+        describe('unipolar (default)', () => {
+            it('output(0) is close to 0 (fade region)', () => {
+                expect(dbLevelResponseMapper.output(0)).toBeCloseTo(0, 2)
+            })
+
+            it('output(1) = 1', () => {
+                expect(dbLevelResponseMapper.output(1)).toBeCloseTo(1, 3)
+            })
+
+            it('is monotonically increasing', () => {
+                let prev = dbLevelResponseMapper.output(0)
+                for (let x = 0.01; x <= 1; x += 0.01) {
+                    const curr = dbLevelResponseMapper.output(x)
+                    expect(curr).toBeGreaterThanOrEqual(prev - 0.0001)
+                    prev = curr
+                }
+            })
+
+            it('round-trips through input/output', () => {
+                for (const x of [0.1, 0.25, 0.5, 0.75, 1]) {
+                    const mapped = dbLevelResponseMapper.output(x)
+                    const recovered = dbLevelResponseMapper.input(mapped)
+                    expect(recovered).toBeCloseTo(x, 2)
+                }
+            })
+        })
+
+        describe('bipolar', () => {
+            it('output(0, bipolar) is negative (dB curve is not symmetric around 0)', () => {
+                // The dB curve maps 0.5 through the unipolar curve, which doesn't
+                // produce exactly 0.5 due to the dB shape, so bipolar 0 maps to a
+                // negative value. This is expected behavior.
+                const val = dbLevelResponseMapper.output(0, true)
+                expect(val).toBeLessThan(0)
+                expect(val).toBeGreaterThan(-1)
+            })
+
+            it('output range is approximately -1 to 1', () => {
+                const atNeg1 = dbLevelResponseMapper.output(-1, true)
+                const at1 = dbLevelResponseMapper.output(1, true)
+                expect(atNeg1).toBeLessThan(-0.5)
+                expect(at1).toBeGreaterThan(0.5)
+            })
+
+            it('round-trips through input/output', () => {
+                for (const x of [-0.8, -0.5, 0, 0.5, 0.8]) {
+                    const mapped = dbLevelResponseMapper.output(x, true)
+                    const recovered = dbLevelResponseMapper.input(mapped, true)
+                    expect(recovered).toBeCloseTo(x, 1)
+                }
+            })
+        })
+    })
+
+    describe('timeResponseMapper', () => {
+        it('output(0) = 0', () => {
+            expect(timeResponseMapper.output(0)).toBeCloseTo(0, 3)
+        })
+
+        it('output(1) = 1', () => {
+            expect(timeResponseMapper.output(1)).toBeCloseTo(1, 3)
+        })
+
+        it('has slow start (exponential with positive steepness)', () => {
+            expect(timeResponseMapper.output(0.5)).toBeLessThan(0.5)
+        })
+
+        it('round-trips through input/output', () => {
+            for (const x of [0, 0.1, 0.25, 0.5, 0.75, 1]) {
+                const mapped = timeResponseMapper.output(x)
+                const recovered = timeResponseMapper.input(mapped)
+                expect(recovered).toBeCloseTo(x, 3)
+            }
+        })
+    })
+
+    describe('uniBipolarLevelResponseMapper', () => {
+        describe('unipolar mode', () => {
+            it('output maps 0 to 0.5', () => {
+                expect(uniBipolarLevelResponseMapper.output(0, false)).toBeCloseTo(0.5, 5)
+            })
+
+            it('output maps 1 to 1', () => {
+                expect(uniBipolarLevelResponseMapper.output(1, false)).toBeCloseTo(1, 5)
+            })
+
+            it('input maps 0.5 to 0', () => {
+                expect(uniBipolarLevelResponseMapper.input(0.5, false)).toBeCloseTo(0, 5)
+            })
+
+            it('input maps 1 to 1', () => {
+                expect(uniBipolarLevelResponseMapper.input(1, false)).toBeCloseTo(1, 5)
+            })
+
+            it('round-trips', () => {
+                for (const x of [0, 0.25, 0.5, 0.75, 1]) {
+                    const mapped = uniBipolarLevelResponseMapper.output(x, false)
+                    const recovered = uniBipolarLevelResponseMapper.input(mapped, false)
+                    expect(recovered).toBeCloseTo(x, 5)
+                }
+            })
+        })
+
+        describe('bipolar mode', () => {
+            it('output maps -1 to 0', () => {
+                expect(uniBipolarLevelResponseMapper.output(-1, true)).toBeCloseTo(0, 5)
+            })
+
+            it('output maps 0 to 0.5', () => {
+                expect(uniBipolarLevelResponseMapper.output(0, true)).toBeCloseTo(0.5, 5)
+            })
+
+            it('output maps 1 to 1', () => {
+                expect(uniBipolarLevelResponseMapper.output(1, true)).toBeCloseTo(1, 5)
+            })
+
+            it('round-trips', () => {
+                for (const x of [-1, -0.5, 0, 0.5, 1]) {
+                    const mapped = uniBipolarLevelResponseMapper.output(x, true)
+                    const recovered = uniBipolarLevelResponseMapper.input(mapped, true)
+                    expect(recovered).toBeCloseTo(x, 5)
+                }
+            })
+        })
+    })
+})

--- a/src/__tests__/synthcore/utils.test.ts
+++ b/src/__tests__/synthcore/utils.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect } from 'vitest'
+import { getBounded, getQuantized, step } from '../../synthcore/utils'
+
+describe('synthcore utils', () => {
+
+    describe('getBounded', () => {
+        it('returns value when within bounds', () => {
+            expect(getBounded(0.5)).toBe(0.5)
+            expect(getBounded(0)).toBe(0)
+            expect(getBounded(1)).toBe(1)
+        })
+
+        it('clamps to upper bound', () => {
+            expect(getBounded(1.5)).toBe(1)
+            expect(getBounded(100)).toBe(1)
+        })
+
+        it('clamps to lower bound', () => {
+            expect(getBounded(-0.5)).toBe(0)
+            expect(getBounded(-100)).toBe(0)
+        })
+
+        it('uses custom bounds', () => {
+            expect(getBounded(5, -10, 10)).toBe(5)
+            expect(getBounded(15, -10, 10)).toBe(10)
+            expect(getBounded(-15, -10, 10)).toBe(-10)
+        })
+
+        it('handles bipolar range', () => {
+            expect(getBounded(0, -1, 1)).toBe(0)
+            expect(getBounded(-0.5, -1, 1)).toBe(-0.5)
+            expect(getBounded(1.5, -1, 1)).toBe(1)
+            expect(getBounded(-1.5, -1, 1)).toBe(-1)
+        })
+    })
+
+    describe('getQuantized', () => {
+        it('quantizes to 16-bit resolution by default', () => {
+            const quantized = getQuantized(0.5)
+            // Should be very close to 0.5 but snapped to nearest 1/65535
+            expect(quantized).toBeCloseTo(0.5, 4)
+            expect(quantized * 65535).toBe(Math.round(quantized * 65535))
+        })
+
+        it('quantizes 0 to exactly 0', () => {
+            expect(getQuantized(0)).toBe(0)
+        })
+
+        it('quantizes 1 to exactly 1', () => {
+            expect(getQuantized(1)).toBe(1)
+        })
+
+        it('supports custom factor', () => {
+            const quantized = getQuantized(0.5, 127)
+            expect(quantized * 127).toBe(Math.round(quantized * 127))
+        })
+    })
+
+    describe('step', () => {
+        it('returns 1 for positive increment', () => {
+            expect(step(0.5)).toBe(1)
+            expect(step(0.001)).toBe(1)
+        })
+
+        it('returns -1 for negative increment', () => {
+            expect(step(-0.5)).toBe(-1)
+            expect(step(-0.001)).toBe(-1)
+        })
+    })
+})

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,3 +1,4 @@
+/// <reference types="vitest" />
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
 import path from 'path'
@@ -39,5 +40,9 @@ export default defineConfig({
     alias: {
       '@': path.resolve(__dirname, './src'),
     },
+  },
+  test: {
+    globals: true,
+    environment: 'node',
   },
 })


### PR DESCRIPTION
## Summary
- Adds Vitest as test framework (natural fit with existing Vite setup)
- Adds `npm test` and `npm run test:watch` scripts
- **83 tests** covering the core pure functions that must be preserved during modernization:
  - `slopeCalculator` — dB mappers, exponential mappers, fade, inverse function
  - `serializer` — 7/8/14/16/21/32-bit MIDI byte splitting, signed int encoding
  - `MIDI value mappers` — CC and NRPN encode/decode round-trips, bipolar handling
  - `responseMappers` — dB level, time (exponential), uni/bipolar level response curves
  - `synthcore/utils` — getBounded, getQuantized, step

## Issues documented in tests
- **NRPN receive bug** (`midibus.ts:287`): `currNRPN.midValue` used in place of `currNRPN.hiValue` when decoding — breaks values > 127
- **Bipolar CC asymmetry**: Encode uses 63-range, decode uses 127-range — output range is ~[-0.5, 0.5] not [-1, 1]

## Test plan
- [x] All 83 tests pass (`npm test`)
- [x] No changes to production code
- [ ] Review: do the tests capture the right contracts?

🤖 Generated with [Claude Code](https://claude.com/claude-code)