### PR TITLE
Fix NRPN receive decode bug (hiValue vs midValue)

### DIFF
--- a/src/midi/midibus.ts
+++ b/src/midi/midibus.ts
@@ -284,7 +284,7 @@ export const receiveMidiMessage = (midiEvent: MIDIMessageEvent) => {
             // don't want to
             currNRPN.loValue = ccValue
             const addr = (currNRPN.hiAddr << 7) + currNRPN.loAddr
-            const value = (currNRPN.midValue << 14) + (currNRPN.midValue << 7) + currNRPN.loValue
+            const value = (currNRPN.hiValue << 14) + (currNRPN.midValue << 7) + currNRPN.loValue
             nrpn.publish(voiceGroupId, addr, value)
             currNRPN.hiValue = 0
             currNRPN.midValue = 0


### PR DESCRIPTION
## Summary
- Fixes a bug in `midibus.ts:287` where `currNRPN.midValue` was used instead of `currNRPN.hiValue` when reconstructing the 21-bit NRPN value from received MIDI bytes
- This caused incorrect decoding for any NRPN value > 127 (anything needing the high 7 bits)

## The bug
```diff
- const value = (currNRPN.midValue << 14) + (currNRPN.midValue << 7) + currNRPN.loValue
+ const value = (currNRPN.hiValue << 14) + (currNRPN.midValue << 7) + currNRPN.loValue
```

## Test plan
- [x] All 83 existing tests pass
- [x] Bug was documented in the NRPN byte-splitting tests from PR #3
- [ ] Verify with hardware: NRPN parameters with values > 127 now decode correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)