### PR TITLE
Phase 2: Add Zustand callback props to pot/button components

### DIFF
--- a/src/components/buttons/RoundButtonBase.tsx
+++ b/src/components/buttons/RoundButtonBase.tsx
@@ -69,14 +69,17 @@ export interface Props {
     // If momentary is true it may have two values - one that is sent on key pressed and one on release.
     momentary?: boolean;
 
-    ctrlGroup: ControllerGroupIds;
-    ctrl: ControllerConfig;
+    ctrlGroup?: ControllerGroupIds;
+    ctrl?: ControllerConfig;
     ctrlIndex?: number;
     value?: number;
     valueIndex?: number;
 
     // Only used if rotary button
     resolution?: number;
+
+    onButtonClick?: () => void;
+    onButtonRelease?: () => void;
 }
 
 type LabelPos = {
@@ -300,46 +303,60 @@ export const RoundButtonBase = (props: Props & Config) => {
         resolution,
         ledRingColors,
         ledCycleBinary,
+        onButtonClick,
+        onButtonRelease,
     } = props
 
-    const storeValue = useAppSelector(selectUiController(ctrl, ctrlIndex || 0))
+    const storeValue = useAppSelector(ctrl ? selectUiController(ctrl, ctrlIndex || 0) : () => 0)
     const currentValue = value !== undefined ? value : storeValue
 
-    // off is always the first element in the midi config values list, so when a radio
-    // button has an off state we need to offset our index by one.
     const radioButtonValueIndex = hasOff ? (radioButtonIndex || 0) + 1 : radioButtonIndex || 0
     const hasOffValue = hasOff || (ledButton && ledCount === undefined)
     const ledOnIndex = hasOffValue ? currentValue - 1 : currentValue
 
     const onIncrement = useCallback((steps: number) => {
-        for (let i = 0; i < Math.abs(steps); i++) {
-            if (steps > 0) {
-                dispatch(click({ ctrlGroup, ctrl, loop, valueIndex, source: ApiSource.UI }))
-            } else {
-                dispatch(click({ ctrlGroup, ctrl, loop, valueIndex, reverse: true, source: ApiSource.UI }))
+        if (onButtonClick) {
+            for (let i = 0; i < Math.abs(steps); i++) {
+                onButtonClick()
+            }
+        } else if (ctrl && ctrlGroup !== undefined) {
+            for (let i = 0; i < Math.abs(steps); i++) {
+                if (steps > 0) {
+                    dispatch(click({ ctrlGroup, ctrl, loop, valueIndex, source: ApiSource.UI }))
+                } else {
+                    dispatch(click({ ctrlGroup, ctrl, loop, valueIndex, reverse: true, source: ApiSource.UI }))
+                }
             }
         }
-    }, [ctrlGroup, ctrl, loop, valueIndex])
+    }, [ctrlGroup, ctrl, loop, valueIndex, onButtonClick])
 
     const handleOnClick = useCallback(() => {
-        dispatch(click({
-            ctrlGroup,
-            ctrl,
-            ctrlIndex,
-            radioButtonIndex,
-            reverse,
-            loop,
-            momentary,
-            source: ApiSource.UI
-        }))
-    }, [ctrlGroup, ctrl, ctrlIndex, radioButtonIndex, reverse, loop, momentary])
+        if (onButtonClick) {
+            onButtonClick()
+        } else if (ctrl && ctrlGroup !== undefined) {
+            dispatch(click({
+                ctrlGroup,
+                ctrl,
+                ctrlIndex,
+                radioButtonIndex,
+                reverse,
+                loop,
+                momentary,
+                source: ApiSource.UI
+            }))
+        }
+    }, [ctrlGroup, ctrl, ctrlIndex, radioButtonIndex, reverse, loop, momentary, onButtonClick])
 
     const handleOnRelease = useCallback(() => {
-        dispatch(release({ ctrlGroup, ctrl, ctrlIndex, momentary, source: ApiSource.UI }))
-    }, [ctrl, ctrlGroup, ctrlIndex, momentary])
+        if (onButtonRelease) {
+            onButtonRelease()
+        } else if (ctrl && ctrlGroup !== undefined) {
+            dispatch(release({ ctrlGroup, ctrl, ctrlIndex, momentary, source: ApiSource.UI }))
+        }
+    }, [ctrl, ctrlGroup, ctrlIndex, momentary, onButtonRelease])
 
     const ledOn: boolean[] = []
-    for (let i = 0; i < (ledCount || (ctrl.values?.length || 2) - 1); i++) {
+    for (let i = 0; i < (ledCount || (ctrl?.values?.length || 2) - 1); i++) {
         ledOn[i] = false
     }
 
@@ -384,7 +401,7 @@ export const RoundButtonBase = (props: Props & Config) => {
     } = getRenderProps(props)
 
     // multiple leds for multi-state led buttons are simulated by blinking the led on the button
-    const modes = ctrl.values?.length || 2
+    const modes = ctrl?.values?.length || 2
     let ledButtonStyle = undefined
     if(ledButton){
         if(radioButtonIndex !== undefined){

--- a/src/components/pots/RotaryPotWithLedRingBase.tsx
+++ b/src/components/pots/RotaryPotWithLedRingBase.tsx
@@ -22,11 +22,12 @@ export interface Props {
     label: string
     value?: number;
     valueIndex?: number;
-    ctrlGroup: ControllerGroupIds;
-    ctrl: ControllerConfig;
+    ctrlGroup?: ControllerGroupIds;
+    ctrl?: ControllerConfig;
     ctrlIndex?: number;
     disabled?: boolean;
     silver?: boolean;
+    onValueIncrement?: (delta: number) => void;
 }
 
 interface Config {
@@ -103,7 +104,7 @@ const RotaryPotWithLedRingBase = (props: Props & Config) => {
 
     // Position should be in the range 0-1 in all modes but pan. In pan the range is -0.5 - 0.5
     const { x, y, ledMode = 'single', potMode = 'normal', label,
-        value, valueIndex, ctrlGroup, ctrl, ctrlIndex, disabled,silver
+        value, valueIndex, ctrlGroup, ctrl, ctrlIndex, disabled, silver, onValueIncrement
     } = props
 
     const dispatch = useAppDispatch()
@@ -120,27 +121,24 @@ const RotaryPotWithLedRingBase = (props: Props & Config) => {
         windowArc,
         ledArc,
     } = getRenderProps(props);
-    // For objects centered around 0, use overflow: visible
-    // For scaling, use viewBox on the outer svg and unitless the rest of the way
 
-    // positive pointer
-    const storeValue = useAppSelector(selectUiController(ctrl, ctrlIndex, valueIndex))
-    const currentValue = value !== undefined ? value :  storeValue
+    const storeValue = useAppSelector(ctrl ? selectUiController(ctrl, ctrlIndex, valueIndex) : () => 0)
+    const currentValue = value !== undefined ? value : storeValue
 
     const ledPosition = getLedPos(centerLed, ledCount, potMode, currentValue)
 
-    // negative pointer used for spread
     const negLedPosition = centerLed - (ledPosition - centerLed)
 
     const onIncrement = useCallback((steps: number, stepSize: number) => {
         if(disabled) return;
 
-        // When panning, we cover a -1 to 1 range instead of 0 to 1.
-        // To keep the line in sync with how much the pot has been
-        // turned we have to make increments twice as big.
-        const value = potMode === 'pan' ? steps * (stepSize * 2) : steps * stepSize
-        dispatch(increment({ ctrlGroup, ctrl, value, valueIndex, ctrlIndex, source: ApiSource.UI }))
-    }, [disabled, potMode, dispatch, ctrlGroup, ctrl, valueIndex, ctrlIndex])
+        const delta = potMode === 'pan' ? steps * (stepSize * 2) : steps * stepSize
+        if (onValueIncrement) {
+            onValueIncrement(delta)
+        } else if (ctrl && ctrlGroup !== undefined) {
+            dispatch(increment({ ctrlGroup, ctrl, value: delta, valueIndex, ctrlIndex, source: ApiSource.UI }))
+        }
+    }, [disabled, potMode, dispatch, ctrlGroup, ctrl, valueIndex, ctrlIndex, onValueIncrement])
 
     return (
         <svg x={x} y={y} className="pot">


### PR DESCRIPTION
## Summary
Adds optional callback props to the shared pot and button components, enabling them to work with Zustand without breaking existing Redux usage.

## Changes
**RotaryPotWithLedRingBase:**
- New `onValueIncrement` prop — when provided, called instead of dispatching Redux `increment`
- `ctrl` and `ctrlGroup` now optional (not needed when using callbacks)

**RoundButtonBase:**
- New `onButtonClick` and `onButtonRelease` props — when provided, called instead of dispatching Redux `click`/`release`
- `ctrl` and `ctrlGroup` now optional

## Backwards compatibility
All existing callers are unaffected — they don't pass the new props, so the components continue using Redux. This enables per-module migration where envelope components can pass Zustand callbacks while everything else stays on Redux.

## Test plan
- [x] All 128 tests pass
- [x] TypeScript compiles cleanly
- [x] Full production build succeeds
- [ ] Manual test: existing UI still functions (pots/buttons respond to interaction)

🤖 Generated with [Claude Code](https://claude.com/claude-code)