### PR TITLE
Phase 2: Wire envelope hardware panel to Zustand

### DIFF
--- a/src/components/modules/right/Envelope.tsx
+++ b/src/components/modules/right/Envelope.tsx
@@ -2,23 +2,19 @@ import React from 'react'
 import RotaryPot12 from '../../pots/RotaryPot12'
 import RoundLedPushButton8 from '../../buttons/RoundLedPushButton8'
 import RoundPushButton8 from '../../buttons/RoundPushButton8'
-import Header from '../../misc/Header'
-import { StageId } from '../../../synthcore/modules/env/types'
-import { useAppSelector } from '../../../synthcore/hooks'
-import { ControllerGroupIds } from '../../../synthcore/types'
-import { envCtrls } from '../../../synthcore/modules/env/envControllers'
-import { selectController } from '../../../synthcore/modules/controllers/controllersReducer'
 import SubHeader from "../../misc/SubHeader";
 import {
-    BUTTON_DISTANCE_S, PADDING_LEFT,
+    BUTTON_DISTANCE_S,
     POT_DISTANCE_L,
     POT_DISTANCE_M,
-    POT_DISTANCE_S,
     POT_OFFSET_Y,
     ROW_HEIGHT
 } from "../../../constants";
 import { ModuleBorder } from "../../misc/ModuleBorder";
 import { ModuleProps } from "../types";
+import { useEnvTime, useEnvLevel, useEnvToggle, useEnvStageEnabled } from '../../../store/modules/useEnvelope'
+import { ControllerGroupIds } from '../../../synthcore/types'
+import { envCtrls } from '../../../synthcore/modules/env/envControllers'
 
 type Props = ModuleProps & {
     x: number,
@@ -31,21 +27,65 @@ type Props = ModuleProps & {
 
 const ctrlGroup = ControllerGroupIds.ENV
 
+const EnvTimePot = ({ envId, stageName, label, x, y, disabled }: {
+    envId: number, stageName: 'delay' | 'attack' | 'decay1' | 'decay2' | 'sustain' | 'release1' | 'release2',
+    label: string, x: number, y: number, disabled?: boolean
+}) => {
+    const { displayValue, increment } = useEnvTime(envId, stageName)
+    return <RotaryPot12
+        ledMode="single"
+        label={label}
+        x={x}
+        y={y}
+        value={displayValue}
+        onValueIncrement={increment}
+        disabled={disabled}
+    />
+}
+
+const EnvLevelPot = ({ envId, stageName, label, x, y, disabled }: {
+    envId: number, stageName: 'delay' | 'attack' | 'decay1' | 'decay2' | 'sustain' | 'release1' | 'release2',
+    label: string, x: number, y: number, disabled?: boolean
+}) => {
+    const { displayValue, bipolar, increment } = useEnvLevel(envId, stageName)
+    return <RotaryPot12
+        ledMode="multi"
+        label={label}
+        x={x}
+        y={y}
+        value={displayValue}
+        potMode={bipolar ? 'pan' : 'normal'}
+        onValueIncrement={increment}
+        disabled={disabled}
+    />
+}
+
+const EnvToggleButton = ({ envId, param, label, x, y }: {
+    envId: number, param: 'loop' | 'invert' | 'velocity',
+    label: string, x: number, y: number
+}) => {
+    const { value, toggle } = useEnvToggle(envId, param)
+    return <RoundLedPushButton8
+        label={label}
+        x={x}
+        y={y}
+        labelPosition="bottom-pot"
+        value={value}
+        onButtonClick={toggle}
+    />
+}
+
 const Envelope = ({ x, y, height, width, label, header, showSelect = false, envId }: Props) => {
     const firstPotX = x + POT_DISTANCE_L / 2
     const topRowY = y + POT_OFFSET_Y
     const bottomRowY = topRowY + ROW_HEIGHT
     const potDistance = POT_DISTANCE_M
 
-    const bipolar = useAppSelector(selectController(envCtrls.BIPOLAR, envId))
-    const env3Id = useAppSelector(selectController(envCtrls.SELECT_ENV3_ID, 0))
-
-    const delayDisabled = useAppSelector(selectController(envCtrls.TOGGLE_STAGE, envId, StageId.DELAY))  === 0
-    const decay1Disabled = useAppSelector(selectController(envCtrls.TOGGLE_STAGE, envId, StageId.DECAY1))  === 0
-    const decay2Disabled = useAppSelector(selectController(envCtrls.TOGGLE_STAGE, envId, StageId.DECAY2))  === 0
-    const sustainDisabled = useAppSelector(selectController(envCtrls.TOGGLE_STAGE, envId, StageId.SUSTAIN))  === 0
-    const release1Disabled = useAppSelector(selectController(envCtrls.TOGGLE_STAGE, envId, StageId.RELEASE1))  === 0
-
+    const delayDisabled = useEnvStageEnabled(envId, 'delay') === 0
+    const decay1Disabled = useEnvStageEnabled(envId, 'decay1') === 0
+    const decay2Disabled = useEnvStageEnabled(envId, 'decay2') === 0
+    const sustainDisabled = useEnvStageEnabled(envId, 'sustain') === 0
+    const release1Disabled = useEnvStageEnabled(envId, 'release1') === 0
 
     return <>
         <ModuleBorder x={x} y={y} height={height} width={width}/>
@@ -57,35 +97,11 @@ const Envelope = ({ x, y, height, width, label, header, showSelect = false, envI
             textAnchor="middle"
             alignmentBaseline="baseline"
         >{label}</text>
-        <RotaryPot12 ledMode="single" label="Attack" x={firstPotX + potDistance * 1} y={topRowY}
-                     ctrlGroup={ctrlGroup}
-                     ctrl={envCtrls.TIME}
-                     ctrlIndex={envId}
-                     valueIndex={StageId.ATTACK}
-        />
-        <RotaryPot12 ledMode="single" label="Decay" x={firstPotX + potDistance * 2} y={topRowY}
-                     ctrlGroup={ctrlGroup}
-                     ctrl={envCtrls.TIME}
-                     ctrlIndex={envId}
-                     valueIndex={StageId.DECAY1}
-                     disabled={decay1Disabled}
-        />
-        <RotaryPot12 ledMode="multi" label="Sustain" x={firstPotX + potDistance * 3} y={topRowY}
-                     ctrlGroup={ctrlGroup}
-                     ctrl={envCtrls.LEVEL}
-                     ctrlIndex={envId}
-                     potMode={bipolar ? 'pan' : 'normal'}
-                     valueIndex={StageId.SUSTAIN}
-                     disabled={sustainDisabled}
-        />
-        <RotaryPot12 ledMode="single" label="Release" x={firstPotX + potDistance * 4} y={topRowY}
-                     ctrlGroup={ctrlGroup}
-                     ctrl={envCtrls.TIME}
-                     ctrlIndex={envId}
-                     valueIndex={StageId.RELEASE1}
-                     disabled={release1Disabled}
 
-        />
+        <EnvTimePot envId={envId} stageName="attack" label="Attack" x={firstPotX + potDistance * 1} y={topRowY} />
+        <EnvTimePot envId={envId} stageName="decay1" label="Decay" x={firstPotX + potDistance * 2} y={topRowY} disabled={decay1Disabled} />
+        <EnvLevelPot envId={envId} stageName="sustain" label="Sustain" x={firstPotX + potDistance * 3} y={topRowY} disabled={sustainDisabled} />
+        <EnvTimePot envId={envId} stageName="release1" label="Release" x={firstPotX + potDistance * 4} y={topRowY} disabled={release1Disabled} />
 
         {showSelect && <RoundPushButton8
           ledPosition="top-horizontal"
@@ -95,65 +111,17 @@ const Envelope = ({ x, y, height, width, label, header, showSelect = false, envI
           ctrlGroup={ctrlGroup}
           ctrl={envCtrls.SELECT_ENV3_ID}
           ctrlIndex={0}
-          value={env3Id -2}
         />}
-        <RotaryPot12 ledMode="single" label="Delay" x={firstPotX} y={bottomRowY}
-                     ctrlGroup={ctrlGroup}
-                     ctrl={envCtrls.TIME}
-                     ctrlIndex={envId}
-                     valueIndex={StageId.DELAY}
-                     disabled={delayDisabled}
-        />
-        <RotaryPot12 ledMode="multi" label="D2 Level" x={firstPotX + potDistance * 1} y={bottomRowY}
-                     ctrlGroup={ctrlGroup}
-                     ctrl={envCtrls.LEVEL}
-                     ctrlIndex={envId}
-                     potMode={bipolar ? 'pan' : 'normal'}
-                     valueIndex={StageId.DECAY2}
-                     disabled={decay2Disabled}
-        />
-        <RotaryPot12 ledMode="single" label="Decay 2" x={firstPotX + potDistance * 2} y={bottomRowY}
-                     ctrlGroup={ctrlGroup}
-                     ctrl={envCtrls.TIME}
-                     ctrlIndex={envId}
-                     valueIndex={StageId.DECAY2}
-                     disabled={decay2Disabled}
-        />
 
-        <RotaryPot12 ledMode="multi" label="R2 Level" x={firstPotX + potDistance * 3} y={bottomRowY}
-                     ctrlGroup={ctrlGroup}
-                     ctrl={envCtrls.LEVEL}
-                     ctrlIndex={envId}
-                     potMode={bipolar ? 'pan' : 'normal'}
-                     valueIndex={StageId.RELEASE2}
-                     disabled={release1Disabled}
-        />
-        <RotaryPot12 ledMode="single" label="Release 2" x={firstPotX + potDistance * 4} y={bottomRowY}
-                     ctrlGroup={ctrlGroup}
-                     ctrl={envCtrls.TIME}
-                     ctrlIndex={envId}
-                     valueIndex={StageId.RELEASE2}
-        />
+        <EnvTimePot envId={envId} stageName="delay" label="Delay" x={firstPotX} y={bottomRowY} disabled={delayDisabled} />
+        <EnvLevelPot envId={envId} stageName="decay2" label="D2 Level" x={firstPotX + potDistance * 1} y={bottomRowY} disabled={decay2Disabled} />
+        <EnvTimePot envId={envId} stageName="decay2" label="Decay 2" x={firstPotX + potDistance * 2} y={bottomRowY} disabled={decay2Disabled} />
+        <EnvLevelPot envId={envId} stageName="release2" label="R2 Level" x={firstPotX + potDistance * 3} y={bottomRowY} disabled={release1Disabled} />
+        <EnvTimePot envId={envId} stageName="release2" label="Release 2" x={firstPotX + potDistance * 4} y={bottomRowY} />
 
-        <RoundLedPushButton8 label="Loop" x={firstPotX + potDistance * 5} y={topRowY} labelPosition="bottom-pot"
-                             ctrlGroup={ctrlGroup}
-                             ctrl={envCtrls.LOOP}
-                             ctrlIndex={envId}
-        />
-        <RoundLedPushButton8
-            label="Invert" x={firstPotX + potDistance * 5 + BUTTON_DISTANCE_S} y={topRowY}
-            labelPosition="bottom-pot"
-            ctrlGroup={ctrlGroup}
-            ctrl={envCtrls.INVERT}
-            ctrlIndex={envId}
-        />
-
-        {/* TODO: Change what this controls! */}
-        <RoundLedPushButton8 label="Velocity" x={firstPotX + potDistance * 5} y={bottomRowY} labelPosition="bottom-pot"
-                             ctrlGroup={ctrlGroup}
-                             ctrl={envCtrls.VELOCITY}
-                             ctrlIndex={envId}
-        />
+        <EnvToggleButton envId={envId} param="loop" label="Loop" x={firstPotX + potDistance * 5} y={topRowY} />
+        <EnvToggleButton envId={envId} param="invert" label="Invert" x={firstPotX + potDistance * 5 + BUTTON_DISTANCE_S} y={topRowY} />
+        <EnvToggleButton envId={envId} param="velocity" label="Velocity" x={firstPotX + potDistance * 5} y={bottomRowY} />
 
         <RoundPushButton8 label="Trigger" x={firstPotX + potDistance * 5 + BUTTON_DISTANCE_S} y={bottomRowY} labelPosition="bottom-pot"
                           ctrlGroup={ctrlGroup}
@@ -161,11 +129,7 @@ const Envelope = ({ x, y, height, width, label, header, showSelect = false, envI
                           ctrlIndex={envId}
                           momentary
         />
-
-
-
     </>
 }
-
 
 export default Envelope

--- a/src/store/modules/useEnvelope.ts
+++ b/src/store/modules/useEnvelope.ts
@@ -1,0 +1,82 @@
+/**
+ * Hooks for connecting envelope UI components to the Zustand store.
+ *
+ * Provides typed, response-mapped access to envelope parameters with
+ * business logic (sustain mirroring, invert resets) handled automatically.
+ */
+
+import { useCallback, useMemo } from 'react'
+import { useVoiceGroupStore, voiceGroupStores, VoiceGroupPatch } from '../patchStore'
+import { useUiStore } from '../uiStore'
+import { StageName, setStageLevel, setStageTime, toggleInvert } from './envActions'
+import { timeResponseMapper, dbLevelResponseMapper } from '../../synthcore/modules/common/responseMappers'
+
+function getBounded(value: number, min: number, max: number): number {
+    if (value > max) return max
+    if (value < min) return min
+    return value
+}
+
+export function useEnvTime(envId: number, stageName: StageName) {
+    const voiceGroupIndex = useUiStore(s => s.currentVoiceGroupIndex)
+    const rawValue = useVoiceGroupStore(voiceGroupIndex, s => s.envelopes[envId].stages[stageName].time)
+
+    const displayValue = useMemo(
+        () => timeResponseMapper.input(rawValue),
+        [rawValue]
+    )
+
+    const increment = useCallback((delta: number) => {
+        const newDisplay = getBounded(displayValue + delta, 0, 1)
+        const newRaw = timeResponseMapper.output(newDisplay)
+        voiceGroupStores[voiceGroupIndex].getState().set(state => {
+            setStageTime(state, envId, stageName, newRaw)
+        })
+    }, [voiceGroupIndex, envId, stageName, displayValue])
+
+    return { displayValue, increment }
+}
+
+export function useEnvLevel(envId: number, stageName: StageName) {
+    const voiceGroupIndex = useUiStore(s => s.currentVoiceGroupIndex)
+    const rawValue = useVoiceGroupStore(voiceGroupIndex, s => s.envelopes[envId].stages[stageName].level)
+    const bipolar = useVoiceGroupStore(voiceGroupIndex, s => s.envelopes[envId].bipolar) === 1
+
+    const displayValue = useMemo(
+        () => dbLevelResponseMapper.input(rawValue, bipolar),
+        [rawValue, bipolar]
+    )
+
+    const increment = useCallback((delta: number) => {
+        const newDisplay = getBounded(displayValue + delta, bipolar ? -1 : 0, 1)
+        const newRaw = dbLevelResponseMapper.output(newDisplay, bipolar)
+        voiceGroupStores[voiceGroupIndex].getState().set(state => {
+            setStageLevel(state, envId, stageName, newRaw)
+        })
+    }, [voiceGroupIndex, envId, stageName, displayValue, bipolar])
+
+    return { displayValue, bipolar, increment }
+}
+
+export function useEnvToggle(envId: number, param: keyof Omit<VoiceGroupPatch['envelopes'][0], 'stages' | 'offset' | 'maxLoops'>) {
+    const voiceGroupIndex = useUiStore(s => s.currentVoiceGroupIndex)
+    const value = useVoiceGroupStore(voiceGroupIndex, s => s.envelopes[envId][param] as number)
+
+    const toggle = useCallback(() => {
+        voiceGroupStores[voiceGroupIndex].getState().set(state => {
+            if (param === 'invert') {
+                toggleInvert(state, envId)
+            } else {
+                const current = state.envelopes[envId][param] as number
+                state.envelopes[envId][param] = current === 0 ? 1 : 0
+            }
+        })
+    }, [voiceGroupIndex, envId, param])
+
+    return { value, toggle }
+}
+
+export function useEnvStageEnabled(envId: number, stageName: StageName) {
+    const voiceGroupIndex = useUiStore(s => s.currentVoiceGroupIndex)
+    return useVoiceGroupStore(voiceGroupIndex, s => s.envelopes[envId].stages[stageName].enabled)
+}


### PR DESCRIPTION
## Summary
The first module fully migrated from Redux to Zustand. The envelope hardware panel component now reads/writes the per-voice-group Zustand stores instead of Redux.

## What changed

**New: `src/store/modules/useEnvelope.ts`**
Custom hooks for envelope parameters:
- `useEnvTime(envId, stageName)` — exponential response mapper, writes via `setStageTime`
- `useEnvLevel(envId, stageName)` — dB response mapper, bipolar-aware, writes via `setStageLevel` (sustain mirroring handled automatically)
- `useEnvToggle(envId, param)` — toggle with `toggleInvert` side effects
- `useEnvStageEnabled(envId, stageName)` — read stage enabled state

**Modified: `src/components/modules/right/Envelope.tsx`**
- Replaced Redux `useAppSelector`/`selectController` with Zustand hooks
- Small sub-components (`EnvTimePot`, `EnvLevelPot`, `EnvToggleButton`) encapsulate hook usage
- Passes `value` + `onValueIncrement`/`onButtonClick` to existing pot/button components
- No more `ctrlGroup`/`ctrl` props for migrated pots/buttons

**Still on Redux:**
- Env selector button (cross-module coordination)
- Trigger button (MIDI-specific momentary behavior)

## Test plan
- [x] All 128 tests pass
- [x] TypeScript compiles cleanly
- [x] Full production build succeeds
- [ ] Manual: envelope pots respond to interaction, values display correctly
- [ ] Manual: sustain mirroring works (set sustain, verify R1/R2 follows)
- [ ] Manual: invert toggle resets stage levels

🤖 Generated with [Claude Code](https://claude.com/claude-code)