### PR TITLE
Phase 2: Zustand → Redux sync for envelope display

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -6,8 +6,10 @@ import * as serviceWorker from './serviceWorker';
 import { Provider } from 'react-redux'
 import { store } from './synthcore/store'
 import midiApi from './midi/midiApi'
+import { startEnvelopeSync } from './store/sync/zustandToReduxSync'
 
 midiApi.initReceive()
+startEnvelopeSync()
 
 const root = ReactDOM.createRoot(
   document.getElementById('root') as HTMLElement

--- a/src/store/sync/zustandToReduxSync.ts
+++ b/src/store/sync/zustandToReduxSync.ts
@@ -1,0 +1,118 @@
+/**
+ * Temporary sync layer: Zustand → Redux
+ *
+ * Subscribes to Zustand voice group stores and writes envelope changes
+ * back into the Redux controllers state, so that the display/touch UI
+ * (which still reads from Redux) stays in sync.
+ *
+ * This is a migration bridge — remove it once the display components
+ * are migrated to Zustand.
+ */
+
+import { voiceGroupStores, EnvelopeState } from '../patchStore'
+import { store as reduxStore } from '../../synthcore/store'
+import { setController } from '../../synthcore/modules/controllers/controllersReducer'
+import { envCtrls } from '../../synthcore/modules/env/envControllers'
+import { StageId, NUMBER_OF_ENVELOPES } from '../../synthcore/modules/env/types'
+import { StageName, STAGE_NAMES } from '../modules/envActions'
+import { dbLevelResponseMapper, timeResponseMapper } from '../../synthcore/modules/common/responseMappers'
+
+const STAGE_NAME_TO_ID: Record<StageName, StageId> = {
+    delay: StageId.DELAY,
+    attack: StageId.ATTACK,
+    decay1: StageId.DECAY1,
+    decay2: StageId.DECAY2,
+    sustain: StageId.SUSTAIN,
+    release1: StageId.RELEASE1,
+    release2: StageId.RELEASE2,
+}
+
+
+function syncSingleEnvelopeToRedux(voiceGroupIndex: number, envId: number, env: EnvelopeState) {
+    for (const stageName of STAGE_NAMES) {
+        const stageId = STAGE_NAME_TO_ID[stageName]
+        const stage = env.stages[stageName]
+
+        reduxStore.dispatch(setController({
+            ctrl: envCtrls.TIME,
+            ctrlIndex: envId,
+            valueIndex: stageId,
+            value: stage.time,
+            uiValue: timeResponseMapper.input(stage.time),
+            voiceGroupIndex,
+        }))
+
+        reduxStore.dispatch(setController({
+            ctrl: envCtrls.LEVEL,
+            ctrlIndex: envId,
+            valueIndex: stageId,
+            value: stage.level,
+            uiValue: dbLevelResponseMapper.input(stage.level, env.bipolar === 1),
+            voiceGroupIndex,
+        }))
+
+        reduxStore.dispatch(setController({
+            ctrl: envCtrls.CURVE,
+            ctrlIndex: envId,
+            valueIndex: stageId,
+            value: stage.curve,
+            voiceGroupIndex,
+        }))
+
+        reduxStore.dispatch(setController({
+            ctrl: envCtrls.TOGGLE_STAGE,
+            ctrlIndex: envId,
+            valueIndex: stageId,
+            value: stage.enabled,
+            voiceGroupIndex,
+        }))
+    }
+
+    reduxStore.dispatch(setController({ ctrl: envCtrls.INVERT, ctrlIndex: envId, value: env.invert, voiceGroupIndex }))
+    reduxStore.dispatch(setController({ ctrl: envCtrls.BIPOLAR, ctrlIndex: envId, value: env.bipolar, voiceGroupIndex }))
+    reduxStore.dispatch(setController({ ctrl: envCtrls.LOOP, ctrlIndex: envId, value: env.loop, voiceGroupIndex }))
+    reduxStore.dispatch(setController({ ctrl: envCtrls.LOOP_MODE, ctrlIndex: envId, value: env.loopMode, voiceGroupIndex }))
+    reduxStore.dispatch(setController({ ctrl: envCtrls.MAX_LOOPS, ctrlIndex: envId, value: env.maxLoops, voiceGroupIndex }))
+    reduxStore.dispatch(setController({ ctrl: envCtrls.VELOCITY, ctrlIndex: envId, value: env.velocity, voiceGroupIndex }))
+    reduxStore.dispatch(setController({ ctrl: envCtrls.RESET_ON_TRIGGER, ctrlIndex: envId, value: env.resetOnTrigger, voiceGroupIndex }))
+    reduxStore.dispatch(setController({ ctrl: envCtrls.RELEASE_MODE, ctrlIndex: envId, value: env.releaseMode, voiceGroupIndex }))
+    reduxStore.dispatch(setController({ ctrl: envCtrls.OFFSET, ctrlIndex: envId, value: env.offset, voiceGroupIndex }))
+}
+
+let unsubscribers: (() => void)[] = []
+
+/**
+ * Start syncing Zustand envelope state to Redux.
+ * Only syncs envelopes that actually changed (immer reference equality).
+ * Call once at app startup.
+ */
+export function startEnvelopeSync() {
+    stopEnvelopeSync()
+
+    voiceGroupStores.forEach((store, voiceGroupIndex) => {
+        let previousEnvelopes = store.getState().envelopes
+
+        const unsub = store.subscribe((state) => {
+            if (state.envelopes !== previousEnvelopes) {
+                const prev = previousEnvelopes
+                previousEnvelopes = state.envelopes
+
+                for (let envId = 0; envId < Math.min(state.envelopes.length, NUMBER_OF_ENVELOPES); envId++) {
+                    if (state.envelopes[envId] !== prev[envId]) {
+                        syncSingleEnvelopeToRedux(voiceGroupIndex, envId, state.envelopes[envId])
+                    }
+                }
+            }
+        })
+
+        unsubscribers.push(unsub)
+    })
+}
+
+/**
+ * Stop syncing. Call on cleanup.
+ */
+export function stopEnvelopeSync() {
+    unsubscribers.forEach(unsub => unsub())
+    unsubscribers = []
+}


### PR DESCRIPTION
## Summary
Temporary bridge layer so the touch screen display (still reading Redux) can see envelope changes made via the hardware panel (now writing Zustand).

## How it works
- Subscribes to each Zustand voice group store at app startup
- When `state.envelopes` changes, uses immer reference equality to find which specific envelope changed
- Dispatches `setController` to Redux for all parameters of that envelope (time, level, curve, enabled, invert, bipolar, loop, etc.)
- Includes `uiValue` (response-mapped display value) so Redux selectors like `selectUiController` return correct values

## Why this is needed
The hardware panel (`Envelope.tsx`) now writes to Zustand, but the display (`controller/envelopes/`) still reads from Redux. Without sync, turning a knob on the hardware panel wouldn't update the display graph.

## Lifecycle
This is explicitly a migration bridge — marked for removal once the display components are migrated to Zustand.

## Test plan
- [x] All 128 tests pass
- [x] TypeScript compiles cleanly
- [x] Full build succeeds
- [ ] Manual: turn envelope pot on hardware panel → verify display graph updates
- [ ] Manual: verify no performance issues from sync dispatches

🤖 Generated with [Claude Code](https://claude.com/claude-code)