### PR TITLE
Phase 2: MIDI send from Zustand envelope state

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -7,9 +7,11 @@ import { Provider } from 'react-redux'
 import { store } from './synthcore/store'
 import midiApi from './midi/midiApi'
 import { startEnvelopeSync } from './store/sync/zustandToReduxSync'
+import { startEnvelopeMidiSend } from './store/midi/envMidiSend'
 
 midiApi.initReceive()
 startEnvelopeSync()
+startEnvelopeMidiSend()
 
 const root = ReactDOM.createRoot(
   document.getElementById('root') as HTMLElement

--- a/src/store/midi/envMidiSend.ts
+++ b/src/store/midi/envMidiSend.ts
@@ -1,0 +1,226 @@
+/**
+ * MIDI send for envelopes: subscribes to Zustand store changes and
+ * sends the changed parameters over MIDI.
+ *
+ * Reuses the existing MIDI infrastructure (envParamSend, paramSend)
+ * which handles env select, NRPN encoding, CC encoding, etc.
+ */
+
+import { voiceGroupStores, EnvelopeState } from '../patchStore'
+import { StageName, STAGE_NAMES } from '../modules/envActions'
+import { envParamSend } from '../../synthcore/modules/env/envMidiApi'
+import { paramSend } from '../../synthcore/modules/common/commonMidiApi'
+import { envCtrls } from '../../synthcore/modules/env/envControllers'
+import { StageId, NUMBER_OF_ENVELOPES } from '../../synthcore/modules/env/types'
+import { ApiSource } from '../../synthcore/types'
+
+const STAGE_NAME_TO_ID: Record<StageName, StageId> = {
+    delay: StageId.DELAY,
+    attack: StageId.ATTACK,
+    decay1: StageId.DECAY1,
+    decay2: StageId.DECAY2,
+    sustain: StageId.SUSTAIN,
+    release1: StageId.RELEASE1,
+    release2: StageId.RELEASE2,
+}
+
+function sendStageParams(
+    voiceGroupIndex: number,
+    envId: number,
+    stageName: StageName,
+    stage: EnvelopeState['stages'][StageName],
+    prevStage: EnvelopeState['stages'][StageName]
+) {
+    const stageId = STAGE_NAME_TO_ID[stageName]
+
+    if (stage.time !== prevStage.time) {
+        envParamSend({
+            ctrl: envCtrls.TIME,
+            ctrlIndex: envId,
+            valueIndex: stageId,
+            value: stage.time,
+            voiceGroupIndex,
+            source: ApiSource.UI,
+        })
+    }
+
+    if (stage.level !== prevStage.level) {
+        envParamSend({
+            ctrl: envCtrls.LEVEL,
+            ctrlIndex: envId,
+            valueIndex: stageId,
+            value: stage.level,
+            voiceGroupIndex,
+            source: ApiSource.UI,
+        })
+    }
+
+    if (stage.curve !== prevStage.curve) {
+        const curveOutputMapper = (curveIndex: number, _cfg: unknown, valueIndex: number = 0) =>
+            (valueIndex << 7) + curveIndex
+
+        envParamSend({
+            ctrl: envCtrls.CURVE,
+            ctrlIndex: envId,
+            valueIndex: stageId,
+            value: stage.curve,
+            voiceGroupIndex,
+            source: ApiSource.UI,
+        }, curveOutputMapper)
+    }
+
+    if (stage.enabled !== prevStage.enabled) {
+        const stageEnabledOutputMapper = (enabled: number, _cfg: unknown, valueIndex: number = 0) => {
+            const enableBit = enabled ? 0b1000 : 0
+            return valueIndex | enableBit
+        }
+
+        envParamSend({
+            ctrl: envCtrls.TOGGLE_STAGE,
+            ctrlIndex: envId,
+            valueIndex: stageId,
+            value: stage.enabled,
+            voiceGroupIndex,
+            source: ApiSource.UI,
+        }, stageEnabledOutputMapper)
+    }
+}
+
+function sendEnvParams(
+    voiceGroupIndex: number,
+    envId: number,
+    env: EnvelopeState,
+    prevEnv: EnvelopeState
+) {
+    for (const stageName of STAGE_NAMES) {
+        const stage = env.stages[stageName]
+        const prevStage = prevEnv.stages[stageName]
+        if (stage !== prevStage) {
+            sendStageParams(voiceGroupIndex, envId, stageName, stage, prevStage)
+        }
+    }
+
+    if (env.invert !== prevEnv.invert) {
+        envParamSend({
+            ctrl: envCtrls.INVERT,
+            ctrlIndex: envId,
+            value: env.invert,
+            voiceGroupIndex,
+            source: ApiSource.UI,
+        }, (value: number) => value)
+    }
+
+    if (env.loop !== prevEnv.loop) {
+        envParamSend({
+            ctrl: envCtrls.LOOP,
+            ctrlIndex: envId,
+            value: env.loop,
+            voiceGroupIndex,
+            source: ApiSource.UI,
+        }, (value: number) => value)
+    }
+
+    if (env.velocity !== prevEnv.velocity) {
+        envParamSend({
+            ctrl: envCtrls.VELOCITY,
+            ctrlIndex: envId,
+            value: env.velocity,
+            voiceGroupIndex,
+            source: ApiSource.UI,
+        }, (value: number) => value)
+    }
+
+    if (env.loopMode !== prevEnv.loopMode) {
+        envParamSend({
+            ctrl: envCtrls.LOOP_MODE,
+            ctrlIndex: envId,
+            value: env.loopMode,
+            voiceGroupIndex,
+            source: ApiSource.UI,
+        }, (value: number) => value)
+    }
+
+    if (env.maxLoops !== prevEnv.maxLoops) {
+        envParamSend({
+            ctrl: envCtrls.MAX_LOOPS,
+            ctrlIndex: envId,
+            value: env.maxLoops,
+            voiceGroupIndex,
+            source: ApiSource.UI,
+        }, (value: number) => value)
+    }
+
+    if (env.resetOnTrigger !== prevEnv.resetOnTrigger) {
+        envParamSend({
+            ctrl: envCtrls.RESET_ON_TRIGGER,
+            ctrlIndex: envId,
+            value: env.resetOnTrigger,
+            voiceGroupIndex,
+            source: ApiSource.UI,
+        }, (value: number) => value)
+    }
+
+    if (env.releaseMode !== prevEnv.releaseMode) {
+        envParamSend({
+            ctrl: envCtrls.RELEASE_MODE,
+            ctrlIndex: envId,
+            value: env.releaseMode,
+            voiceGroupIndex,
+            source: ApiSource.UI,
+        }, (value: number) => value)
+    }
+
+    if (env.bipolar !== prevEnv.bipolar) {
+        envParamSend({
+            ctrl: envCtrls.BIPOLAR,
+            ctrlIndex: envId,
+            value: env.bipolar,
+            voiceGroupIndex,
+            source: ApiSource.UI,
+        }, (value: number) => value)
+    }
+
+    if (env.offset !== prevEnv.offset) {
+        envParamSend({
+            ctrl: envCtrls.OFFSET,
+            ctrlIndex: envId,
+            value: env.offset,
+            voiceGroupIndex,
+            source: ApiSource.UI,
+        })
+    }
+}
+
+let unsubscribers: (() => void)[] = []
+
+/**
+ * Start sending MIDI when Zustand envelope state changes.
+ * Only sends the specific parameters that changed.
+ */
+export function startEnvelopeMidiSend() {
+    stopEnvelopeMidiSend()
+
+    voiceGroupStores.forEach((store, voiceGroupIndex) => {
+        let previousEnvelopes = store.getState().envelopes
+
+        const unsub = store.subscribe((state) => {
+            if (state.envelopes !== previousEnvelopes) {
+                const prev = previousEnvelopes
+                previousEnvelopes = state.envelopes
+
+                for (let envId = 0; envId < Math.min(state.envelopes.length, NUMBER_OF_ENVELOPES); envId++) {
+                    if (state.envelopes[envId] !== prev[envId]) {
+                        sendEnvParams(voiceGroupIndex, envId, state.envelopes[envId], prev[envId])
+                    }
+                }
+            }
+        })
+
+        unsubscribers.push(unsub)
+    })
+}
+
+export function stopEnvelopeMidiSend() {
+    unsubscribers.forEach(unsub => unsub())
+    unsubscribers = []
+}


### PR DESCRIPTION
## Summary
Subscribes to Zustand envelope state changes and sends MIDI for any parameter that changed. Completes the outbound data flow:

```
User turns knob → Zustand store → MIDI send (this PR)
                                 → Redux sync → display update (PR #11)
```

## How it works
- Subscribes to each voice group store
- On envelope change, uses immer reference equality to find exactly which parameters changed
- Calls existing `envParamSend` / `paramSend` — reuses all existing MIDI encoding (env select CC, NRPN, curve bit packing, etc.)
- Only sends the delta, not the full envelope state

## Parameters handled
- Stage time, level, curve, enabled (per stage, per envelope)
- Invert, bipolar, loop, loop mode, max loops, velocity, reset on trigger, release mode, offset

## What's NOT in this PR
- MIDI receive → Zustand (incoming MIDI still goes to Redux via the existing system)
- The hardware panel won't reflect incoming MIDI changes yet

## Test plan
- [x] All 128 tests pass
- [x] TypeScript compiles cleanly  
- [x] Full build succeeds
- [ ] Manual: turn envelope pot → verify MIDI output on connected device
- [ ] Manual: verify env select CC is sent before parameter CCs

🤖 Generated with [Claude Code](https://claude.com/claude-code)