### PR TITLE
Add MIDI receive for envelopes to Zustand

### DIFF
--- a/src/__tests__/store/envMidiReceive.test.ts
+++ b/src/__tests__/store/envMidiReceive.test.ts
@@ -1,0 +1,207 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+
+vi.mock('../../synthcore/synthcoreMiddleware', () => ({
+    synthcoreMiddleware: () => (next: any) => (action: any) => next(action),
+}))
+
+import { cc, nrpn, button } from '../../midi/midibus'
+import { voiceGroupStores, createPatchStore } from '../../store/patchStore'
+import { envCtrls } from '../../synthcore/modules/env/envControllers'
+import { StageId } from '../../synthcore/modules/env/types'
+import { startEnvelopeMidiReceive, stopEnvelopeMidiReceive } from '../../store/midi/envMidiReceive'
+import { curveValuesUsed } from '../../synthcore/modules/env/generatedTypes'
+import { buttonMidiValues } from '../../midi/buttonMidiValues'
+
+const VG = 0
+const ENV = 0
+
+function selectEnv(envId: number) {
+    cc.publish(VG, envCtrls.SELECT.cc, envId)
+}
+
+function getEnv(envId = ENV) {
+    return voiceGroupStores[VG].getState().envelopes[envId]
+}
+
+function encodeNrpn(value: number, valueIndex: number) {
+    return (valueIndex << 16) | (value & 0xFFFF)
+}
+
+function encodeLevel(level: number, stageId: number, bipolar: boolean) {
+    const midiValue = bipolar
+        ? Math.floor(32767 * level + 32767)
+        : Math.floor(65535 * level)
+    return encodeNrpn(midiValue, stageId)
+}
+
+function encodeTime(time: number, stageId: number) {
+    const midiValue = Math.floor(65535 * time)
+    return encodeNrpn(midiValue, stageId)
+}
+
+function encodeCurve(curveIndex: number, stageId: number) {
+    return (stageId << 7) + curveValuesUsed[curveIndex]
+}
+
+function encodeStageEnabled(stageId: number, enabled: boolean) {
+    return stageId | (enabled ? 0b1000 : 0)
+}
+
+describe('envelope MIDI receive', () => {
+    beforeEach(() => {
+        const fresh = createPatchStore()
+        const freshState = fresh.getState().getPatch()
+        voiceGroupStores[VG].getState().loadPatch(freshState)
+        startEnvelopeMidiReceive()
+        selectEnv(ENV)
+    })
+
+    afterEach(() => {
+        stopEnvelopeMidiReceive()
+    })
+
+    describe('level', () => {
+        it('sets decay2 level from NRPN', () => {
+            nrpn.publish(VG, envCtrls.LEVEL.addr, encodeLevel(0.75, StageId.DECAY2, false))
+            expect(getEnv().stages.decay2.level).toBeCloseTo(0.75, 3)
+        })
+
+        it('sets sustain level and mirrors to release stage', () => {
+            nrpn.publish(VG, envCtrls.LEVEL.addr, encodeLevel(0.6, StageId.SUSTAIN, false))
+            const env = getEnv()
+            expect(env.stages.sustain.level).toBeCloseTo(0.6, 3)
+            expect(env.stages.release2.level).toBeCloseTo(0.6, 3)
+        })
+
+        it('handles bipolar level correctly', () => {
+            button.publish(VG, buttonMidiValues.ENV_BIPOLAR_ON)
+            nrpn.publish(VG, envCtrls.LEVEL.addr, encodeLevel(-0.5, StageId.SUSTAIN, true))
+            expect(getEnv().stages.sustain.level).toBeCloseTo(-0.5, 3)
+        })
+    })
+
+    describe('time', () => {
+        it('sets attack time from NRPN', () => {
+            nrpn.publish(VG, envCtrls.TIME.addr, encodeTime(0.3, StageId.ATTACK))
+            expect(getEnv().stages.attack.time).toBeCloseTo(0.3, 3)
+        })
+
+        it('sets release1 time', () => {
+            nrpn.publish(VG, envCtrls.TIME.addr, encodeTime(0.8, StageId.RELEASE1))
+            expect(getEnv().stages.release1.time).toBeCloseTo(0.8, 3)
+        })
+    })
+
+    describe('curve', () => {
+        it('sets stage curve from NRPN', () => {
+            const curveIdx = 3
+            nrpn.publish(VG, envCtrls.CURVE.addr, encodeCurve(curveIdx, StageId.ATTACK))
+            expect(getEnv().stages.attack.curve).toBe(curveIdx)
+        })
+
+        it('ignores invalid curve values', () => {
+            const before = getEnv().stages.attack.curve
+            nrpn.publish(VG, envCtrls.CURVE.addr, (StageId.ATTACK << 7) + 255)
+            expect(getEnv().stages.attack.curve).toBe(before)
+        })
+    })
+
+    describe('toggle stage', () => {
+        it('enables delay stage from CC', () => {
+            cc.publish(VG, envCtrls.TOGGLE_STAGE.cc, encodeStageEnabled(StageId.DELAY, true))
+            expect(getEnv().stages.delay.enabled).toBe(1)
+        })
+
+        it('disables decay1 stage', () => {
+            cc.publish(VG, envCtrls.TOGGLE_STAGE.cc, encodeStageEnabled(StageId.DECAY1, false))
+            expect(getEnv().stages.decay1.enabled).toBe(0)
+        })
+
+        it('mirrors sustain to release1 when release1 enabled', () => {
+            nrpn.publish(VG, envCtrls.LEVEL.addr, encodeLevel(0.7, StageId.SUSTAIN, false))
+            cc.publish(VG, envCtrls.TOGGLE_STAGE.cc, encodeStageEnabled(StageId.RELEASE1, true))
+            expect(getEnv().stages.release1.level).toBeCloseTo(0.7, 3)
+        })
+    })
+
+    describe('offset', () => {
+        it('sets offset from NRPN', () => {
+            const midiValue = Math.floor(32767 * 0.5 + 32767)
+            nrpn.publish(VG, envCtrls.OFFSET.addr, midiValue)
+            expect(getEnv().offset).toBeCloseTo(0.5, 3)
+        })
+    })
+
+    describe('max loops', () => {
+        it('sets max loops from CC', () => {
+            cc.publish(VG, envCtrls.MAX_LOOPS.cc, 42)
+            expect(getEnv().maxLoops).toBe(42)
+        })
+
+        it('bounds max loops to 1-127', () => {
+            cc.publish(VG, envCtrls.MAX_LOOPS.cc, 0)
+            expect(getEnv().maxLoops).toBe(1)
+        })
+    })
+
+    describe('invert', () => {
+        it('sets invert and resets levels', () => {
+            button.publish(VG, buttonMidiValues.ENV_INVERT_ON)
+            const env = getEnv()
+            expect(env.invert).toBe(1)
+            expect(env.stages.delay.level).toBe(1)
+            expect(env.stages.attack.level).toBe(1)
+            expect(env.stages.decay1.level).toBe(0)
+            expect(env.stages.stopped.level).toBe(1)
+        })
+    })
+
+    describe('button params', () => {
+        it('sets loop', () => {
+            button.publish(VG, buttonMidiValues.ENV_LOOP_ON)
+            expect(getEnv().loop).toBe(1)
+        })
+
+        it('sets velocity', () => {
+            button.publish(VG, buttonMidiValues.ENV_VELOCITY_ON)
+            expect(getEnv().velocity).toBe(1)
+        })
+
+        it('sets loop mode', () => {
+            button.publish(VG, buttonMidiValues.ENV_LOOP_MODE_INFINITE)
+            expect(getEnv().loopMode).toBe(2)
+        })
+
+        it('sets release mode', () => {
+            button.publish(VG, buttonMidiValues.ENV_RELEASE_MODE_FREE_RUN)
+            expect(getEnv().releaseMode).toBe(2)
+        })
+
+        it('sets reset on trigger', () => {
+            button.publish(VG, buttonMidiValues.ENV_RESET_ON_TRIGGER_ON)
+            expect(getEnv().resetOnTrigger).toBe(1)
+        })
+
+        it('sets bipolar', () => {
+            button.publish(VG, buttonMidiValues.ENV_BIPOLAR_ON)
+            expect(getEnv().bipolar).toBe(1)
+        })
+    })
+
+    describe('env selection', () => {
+        it('routes to correct envelope after select', () => {
+            selectEnv(2)
+            nrpn.publish(VG, envCtrls.TIME.addr, encodeTime(0.9, StageId.ATTACK))
+            expect(voiceGroupStores[VG].getState().envelopes[2].stages.attack.time).toBeCloseTo(0.9, 3)
+            expect(getEnv().stages.attack.time).not.toBeCloseTo(0.9, 3)
+        })
+
+        it('ignores messages before env select', () => {
+            stopEnvelopeMidiReceive()
+            startEnvelopeMidiReceive()
+            const before = getEnv().stages.attack.time
+            nrpn.publish(VG, envCtrls.TIME.addr, encodeTime(0.9, StageId.ATTACK))
+            expect(getEnv().stages.attack.time).toBe(before)
+        })
+    })
+})

--- a/src/__tests__/store/midiGuard.test.ts
+++ b/src/__tests__/store/midiGuard.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect } from 'vitest'
+import { isMidiReceiving, withMidiReceive } from '../../store/midi/midiGuard'
+
+describe('midiGuard', () => {
+    it('is not receiving by default', () => {
+        expect(isMidiReceiving()).toBe(false)
+    })
+
+    it('sets receiving flag during callback', () => {
+        let wasMidiReceiving = false
+        withMidiReceive(() => {
+            wasMidiReceiving = isMidiReceiving()
+        })
+        expect(wasMidiReceiving).toBe(true)
+        expect(isMidiReceiving()).toBe(false)
+    })
+
+    it('resets flag even if callback throws', () => {
+        try {
+            withMidiReceive(() => {
+                throw new Error('test')
+            })
+        } catch {
+            // expected
+        }
+        expect(isMidiReceiving()).toBe(false)
+    })
+})

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -7,9 +7,11 @@ import { Provider } from 'react-redux'
 import { store } from './synthcore/store'
 import midiApi from './midi/midiApi'
 import { startEnvelopeMidiSend } from './store/midi/envMidiSend'
+import { startEnvelopeMidiReceive } from './store/midi/envMidiReceive'
 
 midiApi.initReceive()
 startEnvelopeMidiSend()
+startEnvelopeMidiReceive()
 
 const root = ReactDOM.createRoot(
   document.getElementById('root') as HTMLElement

--- a/src/store/midi/envMidiReceive.ts
+++ b/src/store/midi/envMidiReceive.ts
@@ -1,0 +1,232 @@
+/**
+ * MIDI receive for envelopes: subscribes to midibus and writes
+ * incoming values to the Zustand stores.
+ *
+ * Mirrors the receive logic from the old ControllerHandler classes
+ * in envApi.ts, but writes to Zustand instead of Redux.
+ */
+
+import { voiceGroupStores } from '../patchStore'
+import { cc, nrpn, button } from '../../midi/midibus'
+import { envCtrls } from '../../synthcore/modules/env/envControllers'
+import { StageId } from '../../synthcore/modules/env/types'
+import { StageName } from '../modules/envActions'
+import {
+    setStageLevel,
+    setStageTime,
+    setStageEnabled,
+    setStageCurve,
+    setInvert,
+    setMaxLoops,
+} from '../modules/envActions'
+import { curveValuesUsed } from '../../synthcore/modules/env/generatedTypes'
+import { withMidiReceive } from './midiGuard'
+
+const STAGE_ID_TO_NAME: Record<number, StageName> = {
+    [StageId.DELAY]: 'delay',
+    [StageId.ATTACK]: 'attack',
+    [StageId.DECAY1]: 'decay1',
+    [StageId.DECAY2]: 'decay2',
+    [StageId.SUSTAIN]: 'sustain',
+    [StageId.RELEASE1]: 'release1',
+    [StageId.RELEASE2]: 'release2',
+    [StageId.STOPPED]: 'stopped',
+}
+
+let currentReceivedEnvId = -1
+let unsubscribers: (() => void)[] = []
+
+function storeForVoiceGroup(voiceGroupIndex: number) {
+    return voiceGroupStores[voiceGroupIndex]
+}
+
+function subscribeEnvSelect() {
+    const cfg = envCtrls.SELECT
+    const id = cc.subscribe((voiceGroupIndex: number, value: number) => {
+        currentReceivedEnvId = value
+    }, cfg)
+    return () => cc.unsubscribe(cfg, id)
+}
+
+function subscribeLevel() {
+    const ctrl = envCtrls.LEVEL
+    const id = nrpn.subscribe((voiceGroupIndex: number, midiValue: number) => {
+        if (currentReceivedEnvId < 0) return
+
+        const valuePart = midiValue & 0xFFFF
+        const stageId = midiValue >> 16
+        const stageName = STAGE_ID_TO_NAME[stageId]
+        if (!stageName) return
+
+        const store = storeForVoiceGroup(voiceGroupIndex)
+        const bipolar = store.getState().envelopes[currentReceivedEnvId]?.bipolar === 1
+        const value = bipolar ? (valuePart - 32767) / 32767 : valuePart / 65535
+
+        withMidiReceive(() => {
+            store.getState().set(state => {
+                setStageLevel(state, currentReceivedEnvId, stageName, value)
+            })
+        })
+    }, ctrl)
+    return () => nrpn.unsubscribe(ctrl, id)
+}
+
+function subscribeTime() {
+    const ctrl = envCtrls.TIME
+    const id = nrpn.subscribe((voiceGroupIndex: number, midiValue: number) => {
+        if (currentReceivedEnvId < 0) return
+
+        const valuePart = midiValue & 0xFFFF
+        const stageId = midiValue >> 16
+        const stageName = STAGE_ID_TO_NAME[stageId]
+        if (!stageName) return
+
+        const value = valuePart / 65535
+
+        withMidiReceive(() => {
+            storeForVoiceGroup(voiceGroupIndex).getState().set(state => {
+                setStageTime(state, currentReceivedEnvId, stageName, value)
+            })
+        })
+    }, ctrl)
+    return () => nrpn.unsubscribe(ctrl, id)
+}
+
+function subscribeCurve() {
+    const ctrl = envCtrls.CURVE
+    // Subscribe without values filter — the raw NRPN value encodes
+    // stageId in upper bits and curve in lower bits, so it won't
+    // match the curveValuesUsed array used for filtering.
+    const subCtrl = { ...ctrl, values: undefined }
+    const id = nrpn.subscribe((voiceGroupIndex: number, midiValue: number) => {
+        if (currentReceivedEnvId < 0) return
+
+        const stageId = (midiValue >> 7)
+        const curve = midiValue & 0b01111111
+        const curveIndex = curveValuesUsed.indexOf(curve)
+        if (curveIndex < 0) return
+
+        const stageName = STAGE_ID_TO_NAME[stageId]
+        if (!stageName) return
+
+        withMidiReceive(() => {
+            storeForVoiceGroup(voiceGroupIndex).getState().set(state => {
+                setStageCurve(state, currentReceivedEnvId, stageName, curveIndex, curveValuesUsed.length)
+            })
+        })
+    }, subCtrl as typeof ctrl)
+    return () => nrpn.unsubscribe(subCtrl as typeof ctrl, id)
+}
+
+function subscribeToggleStage() {
+    const ctrl = envCtrls.TOGGLE_STAGE
+    const id = cc.subscribe((voiceGroupIndex: number, midiValue: number) => {
+        if (currentReceivedEnvId < 0) return
+
+        const stageId = midiValue & 0b111
+        const enabled = (midiValue & 0b1000) > 0 ? 1 : 0
+        const stageName = STAGE_ID_TO_NAME[stageId]
+        if (!stageName) return
+
+        withMidiReceive(() => {
+            storeForVoiceGroup(voiceGroupIndex).getState().set(state => {
+                setStageEnabled(state, currentReceivedEnvId, stageName, enabled)
+            })
+        })
+    }, ctrl)
+    return () => cc.unsubscribe(ctrl, id)
+}
+
+function subscribeOffset() {
+    const ctrl = envCtrls.OFFSET
+    const id = nrpn.subscribe((voiceGroupIndex: number, midiValue: number) => {
+        if (currentReceivedEnvId < 0) return
+
+        const valuePart = midiValue & 0xFFFF
+        const value = ctrl.bipolar ? (valuePart - 32767) / 32767 : valuePart / 65535
+
+        withMidiReceive(() => {
+            storeForVoiceGroup(voiceGroupIndex).getState().set(state => {
+                state.envelopes[currentReceivedEnvId].offset = value
+            })
+        })
+    }, ctrl)
+    return () => nrpn.unsubscribe(ctrl, id)
+}
+
+function subscribeMaxLoops() {
+    const ctrl = envCtrls.MAX_LOOPS
+    const id = cc.subscribe((voiceGroupIndex: number, midiValue: number) => {
+        if (currentReceivedEnvId < 0) return
+
+        withMidiReceive(() => {
+            storeForVoiceGroup(voiceGroupIndex).getState().set(state => {
+                setMaxLoops(state, currentReceivedEnvId, midiValue)
+            })
+        })
+    }, ctrl)
+    return () => cc.unsubscribe(ctrl, id)
+}
+
+function subscribeInvert() {
+    const ctrl = envCtrls.INVERT
+    const id = button.subscribe((voiceGroupIndex: number, midiValue: number) => {
+        if (currentReceivedEnvId < 0) return
+
+        const value = ctrl.values.indexOf(midiValue)
+        if (value < 0) return
+
+        withMidiReceive(() => {
+            storeForVoiceGroup(voiceGroupIndex).getState().set(state => {
+                setInvert(state, currentReceivedEnvId, value)
+            })
+        })
+    }, ctrl)
+    return () => button.unsubscribe(ctrl, id)
+}
+
+function subscribeButtonParam(
+    ctrl: typeof envCtrls.LOOP,
+    field: 'loop' | 'velocity' | 'resetOnTrigger' | 'releaseMode' | 'loopMode' | 'bipolar'
+) {
+    const id = button.subscribe((voiceGroupIndex: number, midiValue: number) => {
+        if (currentReceivedEnvId < 0) return
+
+        const value = ctrl.values.indexOf(midiValue)
+        if (value < 0) return
+
+        withMidiReceive(() => {
+            storeForVoiceGroup(voiceGroupIndex).getState().set(state => {
+                state.envelopes[currentReceivedEnvId][field] = value
+            })
+        })
+    }, ctrl)
+    return () => button.unsubscribe(ctrl, id)
+}
+
+export function startEnvelopeMidiReceive() {
+    stopEnvelopeMidiReceive()
+
+    unsubscribers.push(
+        subscribeEnvSelect(),
+        subscribeLevel(),
+        subscribeTime(),
+        subscribeCurve(),
+        subscribeToggleStage(),
+        subscribeOffset(),
+        subscribeMaxLoops(),
+        subscribeInvert(),
+        subscribeButtonParam(envCtrls.LOOP, 'loop'),
+        subscribeButtonParam(envCtrls.VELOCITY, 'velocity'),
+        subscribeButtonParam(envCtrls.RESET_ON_TRIGGER, 'resetOnTrigger'),
+        subscribeButtonParam(envCtrls.RELEASE_MODE, 'releaseMode'),
+        subscribeButtonParam(envCtrls.LOOP_MODE, 'loopMode'),
+        subscribeButtonParam(envCtrls.BIPOLAR, 'bipolar'),
+    )
+}
+
+export function stopEnvelopeMidiReceive() {
+    unsubscribers.forEach(unsub => unsub())
+    unsubscribers = []
+    currentReceivedEnvId = -1
+}

--- a/src/store/midi/envMidiSend.ts
+++ b/src/store/midi/envMidiSend.ts
@@ -13,6 +13,7 @@ import { paramSend } from '../../synthcore/modules/common/commonMidiApi'
 import { envCtrls } from '../../synthcore/modules/env/envControllers'
 import { StageId, NUMBER_OF_ENVELOPES } from '../../synthcore/modules/env/types'
 import { ApiSource } from '../../synthcore/types'
+import { isMidiReceiving } from './midiGuard'
 
 const STAGE_NAME_TO_ID: Record<StageName, StageId> = {
     delay: StageId.DELAY,
@@ -205,6 +206,10 @@ export function startEnvelopeMidiSend() {
         let previousEnvelopes = store.getState().envelopes
 
         const unsub = store.subscribe((state) => {
+            if (isMidiReceiving()) {
+                previousEnvelopes = state.envelopes
+                return
+            }
             if (state.envelopes !== previousEnvelopes) {
                 const prev = previousEnvelopes
                 previousEnvelopes = state.envelopes

--- a/src/store/midi/midiGuard.ts
+++ b/src/store/midi/midiGuard.ts
@@ -1,0 +1,22 @@
+/**
+ * Guard to prevent MIDI send/receive feedback loops.
+ *
+ * When MIDI receive writes to the Zustand store, the store subscription
+ * in MIDI send would otherwise re-send the same values back out.
+ * Wrap receive-side store writes with withMidiReceive() to suppress sends.
+ */
+
+let receiving = false
+
+export function isMidiReceiving(): boolean {
+    return receiving
+}
+
+export function withMidiReceive(fn: () => void): void {
+    receiving = true
+    try {
+        fn()
+    } finally {
+        receiving = false
+    }
+}


### PR DESCRIPTION
## Summary
- Subscribes to midibus for all envelope MIDI messages and writes received values to Zustand stores via `envActions.ts` business logic
- Adds `midiGuard` module to prevent send/receive feedback loops — MIDI send is suppressed while receive is writing to the store
- Handles: level (with bipolar/sustain mirroring), time, curve, stage toggle, offset, max loops, invert (with level resets), and all button params (loop, velocity, release mode, loop mode, reset on trigger, bipolar)
- Fixed curve NRPN subscription to bypass values filter since the raw MIDI value encodes stageId in upper bits

## Test plan
- [ ] Verify envelope parameters update in UI when receiving MIDI messages
- [ ] Verify no MIDI echo (received values should not be re-sent)
- [ ] Verify sustain mirroring works on MIDI receive (sustain level → R1/R2)
- [ ] Verify invert via MIDI resets delay/attack/decay1/stopped levels
- [ ] Run `yarn vitest` — all 153 tests pass (25 new)

🤖 Generated with [Claude Code](https://claude.com/claude-code)