### PR TITLE
Wire Output Mixer and PostMix to Zustand with MIDI

### DIFF
--- a/src/__tests__/store/ccPotMidi.test.ts
+++ b/src/__tests__/store/ccPotMidi.test.ts
@@ -1,0 +1,140 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+
+vi.mock('../../synthcore/synthcoreMiddleware', () => ({
+    synthcoreMiddleware: () => (next: any) => (action: any) => next(action),
+}))
+
+import { cc } from '../../midi/midibus'
+import { voiceGroupStores, createPatchStore } from '../../store/patchStore'
+import outControllers from '../../synthcore/modules/out/outControllers'
+import postMixControllers from '../../synthcore/modules/postMix/postMixControllers'
+import {
+    startOutPostMixMidiSend,
+    stopOutPostMixMidiSend,
+    startOutPostMixMidiReceive,
+    stopOutPostMixMidiReceive,
+} from '../../store/midi/outMidi'
+
+const VG = 0
+
+function getState() {
+    return voiceGroupStores[VG].getState()
+}
+
+function resetStore() {
+    const fresh = createPatchStore()
+    voiceGroupStores[VG].getState().loadPatch(fresh.getState().getPatch())
+}
+
+describe('CC pot MIDI receive', () => {
+    beforeEach(() => {
+        resetStore()
+        startOutPostMixMidiReceive()
+    })
+
+    afterEach(() => {
+        stopOutPostMixMidiReceive()
+    })
+
+    describe('output', () => {
+        it('sets volume from CC', () => {
+            cc.publish(VG, outControllers.VOLUME.cc, 64)
+            expect(getState().output.volume).toBeCloseTo(64 / 127, 2)
+        })
+
+        it('sets headphones from CC', () => {
+            cc.publish(VG, outControllers.HEADPHONES.cc, 100)
+            expect(getState().output.headphones).toBeCloseTo(100 / 127, 2)
+        })
+
+        it('sets spread from CC', () => {
+            cc.publish(VG, outControllers.SPREAD.cc, 64)
+            expect(getState().output.spread).toBeCloseTo(64 / 127, 2)
+        })
+
+        it('sets spread to zero from CC', () => {
+            cc.publish(VG, outControllers.SPREAD.cc, 0)
+            expect(getState().output.spread).toBeCloseTo(0, 2)
+        })
+    })
+
+    describe('postMix', () => {
+        it('sets LPF from CC', () => {
+            cc.publish(VG, postMixControllers.LPF.cc, 100)
+            expect(getState().postMix.lpf).toBeCloseTo(100 / 127, 2)
+        })
+
+        it('sets SVF from CC', () => {
+            cc.publish(VG, postMixControllers.SVF.cc, 50)
+            expect(getState().postMix.svf).toBeCloseTo(50 / 127, 2)
+        })
+
+        it('sets pan from CC', () => {
+            cc.publish(VG, postMixControllers.PAN.cc, 96)
+            expect(getState().postMix.pan).toBeCloseTo(96 / 127, 2)
+        })
+
+        it('sets amount from CC', () => {
+            cc.publish(VG, postMixControllers.AMOUNT.cc, 127)
+            expect(getState().postMix.amount).toBeCloseTo(1, 2)
+        })
+
+        it('sets fx1Send from CC', () => {
+            cc.publish(VG, postMixControllers.FX1_SEND.cc, 63)
+            expect(getState().postMix.fx1Send).toBeCloseTo(63 / 127, 2)
+        })
+    })
+})
+
+describe('CC pot MIDI send', () => {
+    let sentValues: { ccNum: number, value: number }[] = []
+    const origSend = cc.send
+
+    beforeEach(() => {
+        resetStore()
+        sentValues = []
+        cc.send = vi.fn((vg, ctrl, value) => {
+            sentValues.push({ ccNum: ctrl.cc, value })
+        }) as any
+        startOutPostMixMidiSend()
+    })
+
+    afterEach(() => {
+        stopOutPostMixMidiSend()
+        cc.send = origSend
+    })
+
+    it('sends volume change as CC', () => {
+        getState().set(s => { s.output.volume = 0.5 })
+        const sent = sentValues.find(s => s.ccNum === outControllers.VOLUME.cc)
+        expect(sent).toBeDefined()
+        expect(sent!.value).toBe(Math.floor(127 * 0.5))
+    })
+
+    it('sends spread change as CC', () => {
+        getState().set(s => { s.output.spread = 0.75 })
+        const sent = sentValues.find(s => s.ccNum === outControllers.SPREAD.cc)
+        expect(sent).toBeDefined()
+        expect(sent!.value).toBe(Math.floor(127 * 0.75))
+    })
+
+    it('sends postMix pan change as CC', () => {
+        getState().set(s => { s.postMix.pan = 0.75 })
+        const sent = sentValues.find(s => s.ccNum === postMixControllers.PAN.cc)
+        expect(sent).toBeDefined()
+        expect(sent!.value).toBe(Math.floor(127 * 0.75))
+    })
+
+    it('sends postMix LPF change as CC', () => {
+        getState().set(s => { s.postMix.lpf = 0.8 })
+        const sent = sentValues.find(s => s.ccNum === postMixControllers.LPF.cc)
+        expect(sent).toBeDefined()
+        expect(sent!.value).toBe(Math.floor(127 * 0.8))
+    })
+
+    it('does not send when value unchanged', () => {
+        const defaultVolume = getState().output.volume
+        getState().set(s => { s.output.volume = defaultVolume })
+        expect(sentValues.find(s => s.ccNum === outControllers.VOLUME.cc)).toBeUndefined()
+    })
+})

--- a/src/components/modules/right/OutputMixer.tsx
+++ b/src/components/modules/right/OutputMixer.tsx
@@ -1,37 +1,50 @@
 import React from 'react'
 import RotaryPot12 from '../../pots/RotaryPot12'
-import Header from '../../misc/Header'
 import { PotMode } from '../../pots/RotaryPotWithLedRingBase'
 import { ControllerGroupIds } from '../../../synthcore/types'
 import commonFxControllers from '../../../synthcore/modules/commonFx/commonFxControllers'
-import outControllers from '../../../synthcore/modules/out/outControllers'
 import { ControllerConfig } from '../../../midi/types'
 import { POT_DISTANCE_L, POT_OFFSET_Y, ROW_HEIGHT } from "../../../constants";
 import SubHeader from "../../misc/SubHeader";
 import { ModuleProps } from "../types";
 import { ModuleBorder } from "../../misc/ModuleBorder";
 import "../Modules.scss"
+import { usePot } from '../../../store/hooks'
+import { VoiceGroupPatch } from '../../../store/patchStore'
 
-interface ChannelProps {
+interface FxChannelProps {
     label: string,
-    potMode?: PotMode,
     x: number,
     y: number,
     ctrlGroup: number,
     ctrl: ControllerConfig,
 }
 
-const OutputMixerChannel = ({ x, y, label, potMode = 'normal', ctrlGroup, ctrl }: ChannelProps) => {
-    return <>
-        <RotaryPot12 ledMode="multi" label={label} x={x} y={y} potMode={potMode}
-                     ctrlGroup={ctrlGroup}
-                     ctrl={ctrl}
-        />
-    </>
+const FxMixChannel = ({ x, y, label, ctrlGroup, ctrl }: FxChannelProps) => {
+    return <RotaryPot12 ledMode="multi" label={label} x={x} y={y}
+                 ctrlGroup={ctrlGroup}
+                 ctrl={ctrl}
+    />
+}
+
+const OutPot = ({ x, y, label, potMode = 'normal', selector, mutator }: {
+    x: number, y: number, label: string, potMode?: PotMode,
+    selector: (s: VoiceGroupPatch) => number,
+    mutator: (s: VoiceGroupPatch, v: number) => void,
+}) => {
+    const { displayValue, increment } = usePot(selector, mutator)
+    return <RotaryPot12
+        ledMode="multi"
+        label={label}
+        x={x}
+        y={y}
+        potMode={potMode}
+        value={displayValue}
+        onValueIncrement={increment}
+    />
 }
 
 const ctrlGroupFx = ControllerGroupIds.COMMON_FX
-const ctrlGroupOut = ControllerGroupIds.OUT
 
 const OutputMixer = ({ x, y, height, width }: ModuleProps) => {
     const center = x + POT_DISTANCE_L / 2
@@ -41,41 +54,41 @@ const OutputMixer = ({ x, y, height, width }: ModuleProps) => {
         <ModuleBorder x={x} y={y} height={height} width={width} className="shared-elements-border"/>
         <SubHeader label="Out" x={x} y={y} width={width} labelPosition="center" labelWidth={15}/>
 
-        <OutputMixerChannel x={center} y={topPotY} label="Volume"
-                            ctrlGroup={ctrlGroupOut}
-                            ctrl={outControllers.VOLUME}
+        <OutPot x={center} y={topPotY} label="Volume"
+                selector={s => s.output.volume}
+                mutator={(s, v) => { s.output.volume = v }}
         />
 
-        <OutputMixerChannel x={center} y={topPotY + ROW_HEIGHT} label="Headphones"
-                            ctrlGroup={ctrlGroupOut}
-                            ctrl={outControllers.HEADPHONES}
+        <OutPot x={center} y={topPotY + ROW_HEIGHT} label="Headphones"
+                selector={s => s.output.headphones}
+                mutator={(s, v) => { s.output.headphones = v }}
         />
 
-        <OutputMixerChannel x={center} y={topPotY + ROW_HEIGHT * 2} potMode="spread" label="Spread"
-                            ctrlGroup={ctrlGroupOut}
-                            ctrl={outControllers.SPREAD}
+        <OutPot x={center} y={topPotY + ROW_HEIGHT * 2} label="Spread" potMode="spread"
+                selector={s => s.output.spread}
+                mutator={(s, v) => { s.output.spread = v }}
         />
 
         <ModuleBorder x={x} y={y + ROW_HEIGHT * 4} height={height} width={width} className="shared-elements-border"/>
         <SubHeader label="FX" x={x} y={topPotY + ROW_HEIGHT * 4 - POT_OFFSET_Y} width={width} labelPosition="center" labelWidth={15}/>
-        <OutputMixerChannel x={center} y={topPotY + ROW_HEIGHT * 4} label="DSP 1"
-                            ctrlGroup={ctrlGroupFx}
-                            ctrl={commonFxControllers.FX_MIX.LEVEL_DSP1}
+        <FxMixChannel x={center} y={topPotY + ROW_HEIGHT * 4} label="DSP 1"
+                        ctrlGroup={ctrlGroupFx}
+                        ctrl={commonFxControllers.FX_MIX.LEVEL_DSP1}
         />
 
-        <OutputMixerChannel x={center} y={topPotY + ROW_HEIGHT * 5} label="DSP 2"
-                            ctrlGroup={ctrlGroupFx}
-                            ctrl={commonFxControllers.FX_MIX.LEVEL_DSP2}
+        <FxMixChannel x={center} y={topPotY + ROW_HEIGHT * 5} label="DSP 2"
+                        ctrlGroup={ctrlGroupFx}
+                        ctrl={commonFxControllers.FX_MIX.LEVEL_DSP2}
         />
 
-        <OutputMixerChannel x={center} y={topPotY + ROW_HEIGHT * 6} label="Chorus"
-                            ctrlGroup={ctrlGroupFx}
-                            ctrl={commonFxControllers.FX_MIX.LEVEL_CHORUS}
+        <FxMixChannel x={center} y={topPotY + ROW_HEIGHT * 6} label="Chorus"
+                        ctrlGroup={ctrlGroupFx}
+                        ctrl={commonFxControllers.FX_MIX.LEVEL_CHORUS}
         />
 
-        <OutputMixerChannel x={center} y={topPotY + ROW_HEIGHT * 7} label="Bit crusher"
-                            ctrlGroup={ctrlGroupFx}
-                            ctrl={commonFxControllers.FX_MIX.LEVEL_BIT_CRUSHER}
+        <FxMixChannel x={center} y={topPotY + ROW_HEIGHT * 7} label="Bit crusher"
+                        ctrlGroup={ctrlGroupFx}
+                        ctrl={commonFxControllers.FX_MIX.LEVEL_BIT_CRUSHER}
         />
     </>
 }

--- a/src/components/modules/right/PostMix.tsx
+++ b/src/components/modules/right/PostMix.tsx
@@ -1,41 +1,29 @@
 import React from 'react'
 import RotaryPot12 from '../../pots/RotaryPot12'
-import Header from '../../misc/Header'
 import { LedMode, PotMode } from '../../pots/RotaryPotWithLedRingBase'
-import { ControllerGroupIds } from '../../../synthcore/types'
-import postMixControllers from '../../../synthcore/modules/postMix/postMixControllers'
-import { ControllerConfig } from '../../../midi/types'
-import { POT_DISTANCE_L, POT_DISTANCE_M, POT_OFFSET_Y, ROW_HEIGHT, ROW_SPACING } from "../../../constants";
+import { POT_DISTANCE_L, POT_OFFSET_Y, ROW_HEIGHT } from "../../../constants";
 import SubHeader from "../../misc/SubHeader";
 import { ModuleBorder } from "../../misc/ModuleBorder";
 import { ModuleProps } from "../types";
 import "../Modules.scss"
+import { usePot } from '../../../store/hooks'
+import { VoiceGroupPatch } from '../../../store/patchStore'
 
-interface Props {
-    x: number,
-    y: number
-}
-
-interface ChannelProps {
-    label: string,
-    potMode?: PotMode,
-    ledMode?: LedMode,
-    ctrl: ControllerConfig,
-    x: number,
-    y: number
-}
-
-const ctrlGroup = ControllerGroupIds.POST_MIX
-
-const VoiceMixerChannel = ({ x, y, label, potMode = 'normal', ledMode = 'multi', ctrl }: ChannelProps) => {
-
-    return <>
-        <RotaryPot12 label={label} x={x} y={y} potMode={potMode} ledMode={ledMode}
-                     ctrlGroup={ctrlGroup}
-                     ctrl={ctrl}
-        />
-
-    </>
+const PostMixPot = ({ x, y, label, potMode = 'normal', ledMode = 'multi', selector, mutator }: {
+    x: number, y: number, label: string, potMode?: PotMode, ledMode?: LedMode,
+    selector: (s: VoiceGroupPatch) => number,
+    mutator: (s: VoiceGroupPatch, v: number) => void,
+}) => {
+    const { displayValue, increment } = usePot(selector, mutator)
+    return <RotaryPot12
+        label={label}
+        x={x}
+        y={y}
+        potMode={potMode}
+        ledMode={ledMode}
+        value={displayValue}
+        onValueIncrement={increment}
+    />
 }
 
 const PostMix = ({ x, y, height, width }: ModuleProps) => {
@@ -46,22 +34,41 @@ const PostMix = ({ x, y, height, width }: ModuleProps) => {
     return <>
         <ModuleBorder x={x} y={y} height={height / 2} width={width} className="audio-elements-border"/>
         <SubHeader label="Voice mix" x={x} y={y} width={width} labelPosition="center" labelWidth={22}/>
-        <VoiceMixerChannel x={center} y={offsetY} label="SVF" ctrl={postMixControllers.SVF}/>
-        <VoiceMixerChannel x={center} y={offsetY + ROW_HEIGHT} label="LPF" ctrl={postMixControllers.LPF}/>
-        <VoiceMixerChannel x={center} y={offsetY + ROW_HEIGHT * 2} label="Sine 1" ctrl={postMixControllers.SINE1}/>
-        <VoiceMixerChannel x={center} y={offsetY + ROW_HEIGHT * 3} label="Sine 2" ctrl={postMixControllers.SINE2}/>
-
+        <PostMixPot x={center} y={offsetY} label="SVF"
+                    selector={s => s.postMix.svf}
+                    mutator={(s, v) => { s.postMix.svf = v }}
+        />
+        <PostMixPot x={center} y={offsetY + ROW_HEIGHT} label="LPF"
+                    selector={s => s.postMix.lpf}
+                    mutator={(s, v) => { s.postMix.lpf = v }}
+        />
+        <PostMixPot x={center} y={offsetY + ROW_HEIGHT * 2} label="Sine 1"
+                    selector={s => s.postMix.sine1}
+                    mutator={(s, v) => { s.postMix.sine1 = v }}
+        />
+        <PostMixPot x={center} y={offsetY + ROW_HEIGHT * 3} label="Sine 2"
+                    selector={s => s.postMix.sine2}
+                    mutator={(s, v) => { s.postMix.sine2 = v }}
+        />
 
         <ModuleBorder x={x} y={offsetY2 - POT_OFFSET_Y} height={height / 2} width={width} className="audio-elements-border"/>
         <SubHeader label="Voice out" x={x} y={offsetY2 - POT_OFFSET_Y} width={width} labelPosition="center" labelWidth={22}/>
-        <VoiceMixerChannel x={center} y={offsetY2} label="Pan" potMode="pan" ledMode="single"
-                           ctrl={postMixControllers.PAN}/>
-        <VoiceMixerChannel x={center} y={offsetY2 + ROW_HEIGHT} label="Amt"
-                           ctrl={postMixControllers.AMOUNT}/>
-        <VoiceMixerChannel x={center} y={offsetY2 + ROW_HEIGHT * 2} label="FX1 send"
-                           ctrl={postMixControllers.FX1_SEND}/>
-        <VoiceMixerChannel x={center} y={offsetY2 + ROW_HEIGHT * 3} label="FX2 send"
-                           ctrl={postMixControllers.FX2_SEND}/>
+        <PostMixPot x={center} y={offsetY2} label="Pan" potMode="pan" ledMode="single"
+                    selector={s => s.postMix.pan}
+                    mutator={(s, v) => { s.postMix.pan = v }}
+        />
+        <PostMixPot x={center} y={offsetY2 + ROW_HEIGHT} label="Amt"
+                    selector={s => s.postMix.amount}
+                    mutator={(s, v) => { s.postMix.amount = v }}
+        />
+        <PostMixPot x={center} y={offsetY2 + ROW_HEIGHT * 2} label="FX1 send"
+                    selector={s => s.postMix.fx1Send}
+                    mutator={(s, v) => { s.postMix.fx1Send = v }}
+        />
+        <PostMixPot x={center} y={offsetY2 + ROW_HEIGHT * 3} label="FX2 send"
+                    selector={s => s.postMix.fx2Send}
+                    mutator={(s, v) => { s.postMix.fx2Send = v }}
+        />
     </>
 }
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -10,12 +10,15 @@ import { startEnvelopeMidiSend } from './store/midi/envMidiSend'
 import { startEnvelopeMidiReceive } from './store/midi/envMidiReceive'
 import { startSimpleButtonMidiSend } from './store/midi/simpleButtonMidiSend'
 import { startSimpleButtonMidiReceive } from './store/midi/simpleButtonMidiReceive'
+import { startOutPostMixMidiSend, startOutPostMixMidiReceive } from './store/midi/outMidi'
 
 midiApi.initReceive()
 startEnvelopeMidiSend()
 startEnvelopeMidiReceive()
 startSimpleButtonMidiSend()
 startSimpleButtonMidiReceive()
+startOutPostMixMidiSend()
+startOutPostMixMidiReceive()
 
 const root = ReactDOM.createRoot(
   document.getElementById('root') as HTMLElement

--- a/src/store/midi/ccPotMidi.ts
+++ b/src/store/midi/ccPotMidi.ts
@@ -1,0 +1,87 @@
+import { voiceGroupStores, VoiceGroupPatch } from '../patchStore'
+import { cc } from '../../midi/midibus'
+import { ControllerConfigCC } from '../../midi/types'
+import { isMidiReceiving, withMidiReceive } from './midiGuard'
+
+export interface CCPotMapping {
+    selector: (state: VoiceGroupPatch) => number
+    mutator: (state: VoiceGroupPatch, value: number) => void
+    ctrl: ControllerConfigCC
+}
+
+function toMidi(value: number): number {
+    return Math.floor(127 * value)
+}
+
+function fromMidi(midiValue: number): number {
+    return midiValue / 127
+}
+
+export function createCCPotMidiSend(mappings: CCPotMapping[]) {
+    let unsubscribers: (() => void)[] = []
+
+    function start() {
+        stop()
+
+        voiceGroupStores.forEach((store, voiceGroupIndex) => {
+            let prevState = store.getState()
+
+            const unsub = store.subscribe((state) => {
+                if (isMidiReceiving()) {
+                    prevState = state
+                    return
+                }
+
+                const prev = prevState
+                prevState = state
+
+                for (const mapping of mappings) {
+                    const current = mapping.selector(state)
+                    const previous = mapping.selector(prev)
+                    if (current !== previous) {
+                        const midiValue = toMidi(current)
+                        cc.send(voiceGroupIndex, mapping.ctrl, midiValue)
+                    }
+                }
+            })
+
+            unsubscribers.push(unsub)
+        })
+    }
+
+    function stop() {
+        unsubscribers.forEach(unsub => unsub())
+        unsubscribers = []
+    }
+
+    return { start, stop }
+}
+
+export function createCCPotMidiReceive(mappings: CCPotMapping[]) {
+    let unsubscribers: (() => void)[] = []
+
+    function start() {
+        stop()
+
+        for (const mapping of mappings) {
+            const id = cc.subscribe((voiceGroupIndex: number, midiValue: number) => {
+                const value = fromMidi(midiValue)
+
+                withMidiReceive(() => {
+                    voiceGroupStores[voiceGroupIndex].getState().set(state => {
+                        mapping.mutator(state, value)
+                    })
+                })
+            }, mapping.ctrl)
+
+            unsubscribers.push(() => cc.unsubscribe(mapping.ctrl, id))
+        }
+    }
+
+    function stop() {
+        unsubscribers.forEach(unsub => unsub())
+        unsubscribers = []
+    }
+
+    return { start, stop }
+}

--- a/src/store/midi/outMidi.ts
+++ b/src/store/midi/outMidi.ts
@@ -1,0 +1,74 @@
+import outControllers from '../../synthcore/modules/out/outControllers'
+import postMixControllers from '../../synthcore/modules/postMix/postMixControllers'
+import { CCPotMapping, createCCPotMidiSend, createCCPotMidiReceive } from './ccPotMidi'
+
+const outputMappings: CCPotMapping[] = [
+    {
+        selector: s => s.output.volume,
+        mutator: (s, v) => { s.output.volume = v },
+        ctrl: outControllers.VOLUME,
+    },
+    {
+        selector: s => s.output.headphones,
+        mutator: (s, v) => { s.output.headphones = v },
+        ctrl: outControllers.HEADPHONES,
+    },
+    {
+        selector: s => s.output.spread,
+        mutator: (s, v) => { s.output.spread = v },
+        ctrl: outControllers.SPREAD,
+    },
+]
+
+const postMixMappings: CCPotMapping[] = [
+    {
+        selector: s => s.postMix.lpf,
+        mutator: (s, v) => { s.postMix.lpf = v },
+        ctrl: postMixControllers.LPF,
+    },
+    {
+        selector: s => s.postMix.svf,
+        mutator: (s, v) => { s.postMix.svf = v },
+        ctrl: postMixControllers.SVF,
+    },
+    {
+        selector: s => s.postMix.sine1,
+        mutator: (s, v) => { s.postMix.sine1 = v },
+        ctrl: postMixControllers.SINE1,
+    },
+    {
+        selector: s => s.postMix.sine2,
+        mutator: (s, v) => { s.postMix.sine2 = v },
+        ctrl: postMixControllers.SINE2,
+    },
+    {
+        selector: s => s.postMix.pan,
+        mutator: (s, v) => { s.postMix.pan = v },
+        ctrl: postMixControllers.PAN,
+    },
+    {
+        selector: s => s.postMix.amount,
+        mutator: (s, v) => { s.postMix.amount = v },
+        ctrl: postMixControllers.AMOUNT,
+    },
+    {
+        selector: s => s.postMix.fx1Send,
+        mutator: (s, v) => { s.postMix.fx1Send = v },
+        ctrl: postMixControllers.FX1_SEND,
+    },
+    {
+        selector: s => s.postMix.fx2Send,
+        mutator: (s, v) => { s.postMix.fx2Send = v },
+        ctrl: postMixControllers.FX2_SEND,
+    },
+]
+
+const allMappings = [...outputMappings, ...postMixMappings]
+
+const send = createCCPotMidiSend(allMappings)
+const receive = createCCPotMidiReceive(allMappings)
+
+export function startOutPostMixMidiSend() { send.start() }
+export function stopOutPostMixMidiSend() { send.stop() }
+export function startOutPostMixMidiReceive() { receive.start() }
+export function stopOutPostMixMidiReceive() { receive.stop() }


### PR DESCRIPTION
## Summary
- Replace `ctrlGroup`/`ctrl` Redux pattern with `usePot` Zustand hook in Output Mixer (Volume, Headphones, Spread) and PostMix (all 8 pots)
- FX mix section of Output Mixer stays on old pattern (not yet in patch store)
- Add reusable `ccPotMidi.ts` with generic CC pot MIDI send/receive helpers (mapping-based, scales to more modules)
- 14 new tests covering CC MIDI send and receive for both modules

## Notes
- All pot values stored as 0-1 (unipolar). `potMode="pan"/"spread"` handles visual centering at 0.5
- CC MIDI encoding is always linear 0-127 matching the 0-1 store range

## Test plan
- [x] All 167 tests pass, no regressions
- [ ] Verify Output Mixer pots (Volume, Headphones, Spread) respond in UI
- [ ] Verify PostMix pots respond in UI
- [ ] Verify MIDI send/receive for output and postMix parameters

🤖 Generated with [Claude Code](https://claude.com/claude-code)