### PR TITLE
Wire Source Mixer to Zustand with MIDI

### DIFF
--- a/src/__tests__/store/srcMixMidi.test.ts
+++ b/src/__tests__/store/srcMixMidi.test.ts
@@ -1,0 +1,146 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+
+vi.mock('../../synthcore/synthcoreMiddleware', () => ({
+    synthcoreMiddleware: () => (next: any) => (action: any) => next(action),
+}))
+
+import { cc, button } from '../../midi/midibus'
+import { voiceGroupStores, createPatchStore } from '../../store/patchStore'
+import srcMixControllers from '../../synthcore/modules/srcMix/srcMixControllers'
+import { buttonMidiValues } from '../../midi/buttonMidiValues'
+import {
+    startSrcMixMidiSend,
+    stopSrcMixMidiSend,
+    startSrcMixMidiReceive,
+    stopSrcMixMidiReceive,
+} from '../../store/midi/srcMixMidi'
+
+const VG = 0
+
+function getState() {
+    return voiceGroupStores[VG].getState()
+}
+
+function resetStore() {
+    const fresh = createPatchStore()
+    voiceGroupStores[VG].getState().loadPatch(fresh.getState().getPatch())
+}
+
+describe('source mixer MIDI receive', () => {
+    beforeEach(() => {
+        resetStore()
+        startSrcMixMidiReceive()
+    })
+
+    afterEach(() => {
+        stopSrcMixMidiReceive()
+    })
+
+    describe('levels', () => {
+        it('sets levelOsc1 from CC', () => {
+            cc.publish(VG, srcMixControllers.LEVEL_OSC1.cc, 100)
+            expect(getState().srcMix.levelOsc1).toBeCloseTo(100 / 127, 2)
+        })
+
+        it('sets levelNoise from CC', () => {
+            cc.publish(VG, srcMixControllers.LEVEL_NOISE.cc, 64)
+            expect(getState().srcMix.levelNoise).toBeCloseTo(64 / 127, 2)
+        })
+
+        it('sets levelExtAudio to zero', () => {
+            cc.publish(VG, srcMixControllers.LEVEL_EXT_AUDIO.cc, 0)
+            expect(getState().srcMix.levelExtAudio).toBeCloseTo(0, 2)
+        })
+    })
+
+    describe('output routing', () => {
+        it('sets outOsc1 to A from button MIDI', () => {
+            button.publish(VG, buttonMidiValues.OSC1_OUT_A)
+            expect(getState().srcMix.outOsc1).toBe(1)
+        })
+
+        it('sets outOsc1 to B from button MIDI', () => {
+            button.publish(VG, buttonMidiValues.OSC1_OUT_B)
+            expect(getState().srcMix.outOsc1).toBe(2)
+        })
+
+        it('sets outOsc1 to Both from button MIDI', () => {
+            button.publish(VG, buttonMidiValues.OSC1_OUT_BOTH)
+            expect(getState().srcMix.outOsc1).toBe(3)
+        })
+
+        it('sets outOsc1 to Off from button MIDI', () => {
+            getState().set(s => { s.srcMix.outOsc1 = 2 })
+            button.publish(VG, buttonMidiValues.OSC1_OUT_OFF)
+            expect(getState().srcMix.outOsc1).toBe(0)
+        })
+
+        it('sets outNoise from button MIDI', () => {
+            button.publish(VG, buttonMidiValues.NOISE_OUT_B)
+            expect(getState().srcMix.outNoise).toBe(2)
+        })
+
+        it('sets outRingMod from button MIDI', () => {
+            button.publish(VG, buttonMidiValues.RING_MOD_OUT_BOTH)
+            expect(getState().srcMix.outRingMod).toBe(3)
+        })
+    })
+})
+
+describe('source mixer MIDI send', () => {
+    let sentCC: { ccNum: number, value: number }[] = []
+    let sentButtons: { ctrl: any, value: number }[] = []
+    const origCCSend = cc.send
+    const origButtonSend = button.send
+
+    beforeEach(() => {
+        resetStore()
+        sentCC = []
+        sentButtons = []
+        cc.send = vi.fn((vg, ctrl, value) => {
+            sentCC.push({ ccNum: ctrl.cc, value })
+        }) as any
+        button.send = vi.fn((vg, ctrl, value) => {
+            sentButtons.push({ ctrl, value })
+        }) as any
+        startSrcMixMidiSend()
+    })
+
+    afterEach(() => {
+        stopSrcMixMidiSend()
+        cc.send = origCCSend
+        button.send = origButtonSend
+    })
+
+    it('sends levelOsc1 change as CC', () => {
+        getState().set(s => { s.srcMix.levelOsc1 = 0.5 })
+        const sent = sentCC.find(s => s.ccNum === srcMixControllers.LEVEL_OSC1.cc)
+        expect(sent).toBeDefined()
+        expect(sent!.value).toBe(Math.floor(127 * 0.5))
+    })
+
+    it('sends levelRingMod change as CC', () => {
+        getState().set(s => { s.srcMix.levelRingMod = 0.8 })
+        const sent = sentCC.find(s => s.ccNum === srcMixControllers.LEVEL_RING_MOD.cc)
+        expect(sent).toBeDefined()
+        expect(sent!.value).toBe(Math.floor(127 * 0.8))
+    })
+
+    it('sends outOsc2 change as button MIDI', () => {
+        getState().set(s => { s.srcMix.outOsc2 = 2 })
+        expect(sentButtons).toHaveLength(1)
+        expect(sentButtons[0].value).toBe(buttonMidiValues.OSC2_OUT_B)
+    })
+
+    it('sends outExtAudio change as button MIDI', () => {
+        getState().set(s => { s.srcMix.outExtAudio = 3 })
+        expect(sentButtons).toHaveLength(1)
+        expect(sentButtons[0].value).toBe(buttonMidiValues.EXT_AUDIO_OUT_BOTH)
+    })
+
+    it('does not send when value unchanged', () => {
+        const defaultLevel = getState().srcMix.levelOsc2
+        getState().set(s => { s.srcMix.levelOsc2 = defaultLevel })
+        expect(sentCC.find(s => s.ccNum === srcMixControllers.LEVEL_OSC2.cc)).toBeUndefined()
+    })
+})

--- a/src/components/modules/left2/SourceMixer.tsx
+++ b/src/components/modules/left2/SourceMixer.tsx
@@ -1,53 +1,76 @@
 import React from 'react'
 import RoundPushButton8 from '../../buttons/RoundPushButton8'
-import { ControllerGroupIds } from '../../../synthcore/types'
-import srcMixControllers from '../../../synthcore/modules/srcMix/srcMixControllers'
-import { ControllerConfig } from '../../../midi/types'
 import RotaryPot12 from "../../pots/RotaryPot12";
 import SubHeader from "../../misc/SubHeader";
 import {
-    BUTTON_DISTANCE_S,
-    DUAL_LED_BUTTON_NO_LABEL_OFFSET_Y, DUAL_LED_BUTTON_W_LABEL_OFFSET_Y, POT_DISTANCE_L, POT_DISTANCE_M, POT_DISTANCE_S,
+    DUAL_LED_BUTTON_W_LABEL_OFFSET_Y, POT_DISTANCE_L, POT_DISTANCE_M, POT_DISTANCE_S,
     POT_OFFSET_Y,
-    ROW_HEIGHT, ROW_SPACING
+    ROW_HEIGHT,
 } from "../../../constants";
-import { SHOW_CUT } from "../../../config";
 import { ModuleBorder } from "../../misc/ModuleBorder";
 import { ModuleProps } from "../types";
 import "../Modules.scss"
+import { usePot, useButton } from '../../../store/hooks'
+import { VoiceGroupPatch } from '../../../store/patchStore'
+import { dbLevelResponseMapper } from '../../../synthcore/modules/common/responseMappers'
 
-interface ChannelProps {
-    label: string,
-    x: number,
-    y: number,
-    levelCtrl: ControllerConfig,
-    outCtrl: ControllerConfig,
+const SrcMixLevelPot = ({ x, y, label, selector, mutator }: {
+    x: number, y: number, label: string,
+    selector: (s: VoiceGroupPatch) => number,
+    mutator: (s: VoiceGroupPatch, v: number) => void,
+}) => {
+    const { displayValue, increment } = usePot(selector, mutator, { responseMapper: dbLevelResponseMapper })
+    return <RotaryPot12
+        ledMode="multi"
+        label={label}
+        x={x}
+        y={y}
+        value={displayValue}
+        onValueIncrement={increment}
+    />
 }
 
-const ctrlGroup = ControllerGroupIds.SRC_MIX
+const SrcMixOutButton = ({ x, y, selector, mutator }: {
+    x: number, y: number,
+    selector: (s: VoiceGroupPatch) => number,
+    mutator: (s: VoiceGroupPatch, v: number) => void,
+}) => {
+    const { value, toggle } = useButton(selector, mutator, 4)
+    return <RoundPushButton8
+        x={x}
+        y={y + DUAL_LED_BUTTON_W_LABEL_OFFSET_Y}
+        ledPosition="top-horizontal-no-label"
+        ledCount={2}
+        ledRingColors={['#00bfa6', '#ff8700']}
+        label="To"
+        labelPosition="bottom"
+        hasOff
+        value={value}
+        onButtonClick={toggle}
+    />
+}
 
-const MixerChannel = ({ x, y, label, levelCtrl, outCtrl }: ChannelProps) => {
+const MixerChannel = ({ x, y, label, levelSelector, levelMutator, outSelector, outMutator }: {
+    x: number, y: number, label: string,
+    levelSelector: (s: VoiceGroupPatch) => number,
+    levelMutator: (s: VoiceGroupPatch, v: number) => void,
+    outSelector: (s: VoiceGroupPatch) => number,
+    outMutator: (s: VoiceGroupPatch, v: number) => void,
+}) => {
     return <>
-        <RotaryPot12 ledMode="multi" label={label} x={x} y={y}
-                     ctrlGroup={ctrlGroup}
-                     ctrl={levelCtrl}
+        <SrcMixLevelPot x={x} y={y} label={label}
+                        selector={levelSelector}
+                        mutator={levelMutator}
         />
-
-        <RoundPushButton8 x={x + POT_DISTANCE_S} y={y + (DUAL_LED_BUTTON_W_LABEL_OFFSET_Y)}
-                          ledPosition="top-horizontal-no-label" ledCount={2}
-                          ledRingColors={['#00bfa6', '#ff8700']}
-                          label="To"
-                          labelPosition="bottom"
-                          hasOff
-                          ctrlGroup={ctrlGroup}
-                          ctrl={outCtrl}
+        <SrcMixOutButton x={x + POT_DISTANCE_S} y={y}
+                         selector={outSelector}
+                         mutator={outMutator}
         />
     </>
 }
 
 const SourceMixer = ({ x, y, height, width }: ModuleProps) => {
     const colDistance = POT_DISTANCE_L
-
 
     const col1 = x + POT_DISTANCE_M / 2
     const col2 = col1 + colDistance
@@ -56,36 +79,46 @@ const SourceMixer = ({ x, y, height, width }: ModuleProps) => {
     const row2 = row1 + ROW_HEIGHT
     const row3 = row2 + ROW_HEIGHT
 
-
     return <>
-        {/*!SHOW_CUT && <rect x={x} y={y} width="135" height={2 * ROW_HEIGHT - ROW_SPACING} className="module-background"/> */ }
         <ModuleBorder x={x} y={y} height={height} width={width} className="audio-elements-border"/>
         <SubHeader label="Mix" x={x} y={y} width={width} labelWidth={15} labelPosition="center"/>
 
         <MixerChannel x={col1} y={row1} label="Osc 1"
-                      levelCtrl={srcMixControllers.LEVEL_OSC1}
-                      outCtrl={srcMixControllers.OUT_OSC1}
+                      levelSelector={s => s.srcMix.levelOsc1}
+                      levelMutator={(s, v) => { s.srcMix.levelOsc1 = v }}
+                      outSelector={s => s.srcMix.outOsc1}
+                      outMutator={(s, v) => { s.srcMix.outOsc1 = v }}
         />
         <MixerChannel x={col1} y={row2} label="Osc 2"
-                      levelCtrl={srcMixControllers.LEVEL_OSC2}
-                      outCtrl={srcMixControllers.OUT_OSC2}
+                      levelSelector={s => s.srcMix.levelOsc2}
+                      levelMutator={(s, v) => { s.srcMix.levelOsc2 = v }}
+                      outSelector={s => s.srcMix.outOsc2}
+                      outMutator={(s, v) => { s.srcMix.outOsc2 = v }}
         />
         <MixerChannel x={col1} y={row3} label="Osc 3"
-                      levelCtrl={srcMixControllers.LEVEL_OSC3}
-                      outCtrl={srcMixControllers.OUT_OSC3}
+                      levelSelector={s => s.srcMix.levelOsc3}
+                      levelMutator={(s, v) => { s.srcMix.levelOsc3 = v }}
+                      outSelector={s => s.srcMix.outOsc3}
+                      outMutator={(s, v) => { s.srcMix.outOsc3 = v }}
         />
 
         <MixerChannel x={col2} y={row1} label="Noise"
-                      levelCtrl={srcMixControllers.LEVEL_NOISE}
-                      outCtrl={srcMixControllers.OUT_NOISE}
+                      levelSelector={s => s.srcMix.levelNoise}
+                      levelMutator={(s, v) => { s.srcMix.levelNoise = v }}
+                      outSelector={s => s.srcMix.outNoise}
+                      outMutator={(s, v) => { s.srcMix.outNoise = v }}
         />
         <MixerChannel x={col2} y={row2} label="Ring mod"
-                      levelCtrl={srcMixControllers.LEVEL_RING_MOD}
-                      outCtrl={srcMixControllers.OUT_RING_MOD}
+                      levelSelector={s => s.srcMix.levelRingMod}
+                      levelMutator={(s, v) => { s.srcMix.levelRingMod = v }}
+                      outSelector={s => s.srcMix.outRingMod}
+                      outMutator={(s, v) => { s.srcMix.outRingMod = v }}
         />
         <MixerChannel x={col2} y={row3} label="Ext audio"
-                      levelCtrl={srcMixControllers.LEVEL_EXT_AUDIO}
-                      outCtrl={srcMixControllers.OUT_EXT_AUDIO}
+                      levelSelector={s => s.srcMix.levelExtAudio}
+                      levelMutator={(s, v) => { s.srcMix.levelExtAudio = v }}
+                      outSelector={s => s.srcMix.outExtAudio}
+                      outMutator={(s, v) => { s.srcMix.outExtAudio = v }}
         />
     </>
 }

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -10,12 +10,15 @@ import { startEnvelopeMidiSend } from './store/midi/envMidiSend'
 import { startEnvelopeMidiReceive } from './store/midi/envMidiReceive'
 import { startSimpleButtonMidiSend } from './store/midi/simpleButtonMidiSend'
 import { startSimpleButtonMidiReceive } from './store/midi/simpleButtonMidiReceive'
+import { startSrcMixMidiSend, startSrcMixMidiReceive } from './store/midi/srcMixMidi'
 
 midiApi.initReceive()
 startEnvelopeMidiSend()
 startEnvelopeMidiReceive()
 startSimpleButtonMidiSend()
 startSimpleButtonMidiReceive()
+startSrcMixMidiSend()
+startSrcMixMidiReceive()
 
 const root = ReactDOM.createRoot(
   document.getElementById('root') as HTMLElement

--- a/src/store/midi/srcMixMidi.ts
+++ b/src/store/midi/srcMixMidi.ts
@@ -1,0 +1,102 @@
+import { voiceGroupStores, VoiceGroupPatch, SrcMixState } from '../patchStore'
+import { cc, button } from '../../midi/midibus'
+import { ControllerConfigCC, ControllerConfigButton } from '../../midi/types'
+import srcMixControllers from '../../synthcore/modules/srcMix/srcMixControllers'
+import { isMidiReceiving, withMidiReceive } from './midiGuard'
+
+type LevelField = 'levelOsc1' | 'levelOsc2' | 'levelOsc3' | 'levelNoise' | 'levelRingMod' | 'levelExtAudio'
+type OutField = 'outOsc1' | 'outOsc2' | 'outOsc3' | 'outNoise' | 'outRingMod' | 'outExtAudio'
+
+const levelMappings: { field: LevelField, ctrl: ControllerConfigCC }[] = [
+    { field: 'levelOsc1', ctrl: srcMixControllers.LEVEL_OSC1 },
+    { field: 'levelOsc2', ctrl: srcMixControllers.LEVEL_OSC2 },
+    { field: 'levelOsc3', ctrl: srcMixControllers.LEVEL_OSC3 },
+    { field: 'levelNoise', ctrl: srcMixControllers.LEVEL_NOISE },
+    { field: 'levelRingMod', ctrl: srcMixControllers.LEVEL_RING_MOD },
+    { field: 'levelExtAudio', ctrl: srcMixControllers.LEVEL_EXT_AUDIO },
+]
+
+const outMappings: { field: OutField, ctrl: ControllerConfigButton }[] = [
+    { field: 'outOsc1', ctrl: srcMixControllers.OUT_OSC1 },
+    { field: 'outOsc2', ctrl: srcMixControllers.OUT_OSC2 },
+    { field: 'outOsc3', ctrl: srcMixControllers.OUT_OSC3 },
+    { field: 'outNoise', ctrl: srcMixControllers.OUT_NOISE },
+    { field: 'outRingMod', ctrl: srcMixControllers.OUT_RING_MOD },
+    { field: 'outExtAudio', ctrl: srcMixControllers.OUT_EXT_AUDIO },
+]
+
+let unsubscribers: (() => void)[] = []
+
+export function startSrcMixMidiSend() {
+    stopSrcMixMidiSend()
+
+    voiceGroupStores.forEach((store, voiceGroupIndex) => {
+        let prevSrcMix = store.getState().srcMix
+
+        const unsub = store.subscribe((state) => {
+            if (isMidiReceiving()) {
+                prevSrcMix = state.srcMix
+                return
+            }
+
+            if (state.srcMix === prevSrcMix) return
+            const prev = prevSrcMix
+            prevSrcMix = state.srcMix
+
+            for (const { field, ctrl } of levelMappings) {
+                if (state.srcMix[field] !== prev[field]) {
+                    cc.send(voiceGroupIndex, ctrl, Math.floor(127 * state.srcMix[field]))
+                }
+            }
+
+            for (const { field, ctrl } of outMappings) {
+                if (state.srcMix[field] !== prev[field]) {
+                    button.send(voiceGroupIndex, ctrl, ctrl.values[state.srcMix[field]])
+                }
+            }
+        })
+
+        unsubscribers.push(unsub)
+    })
+}
+
+export function stopSrcMixMidiSend() {
+    unsubscribers.forEach(unsub => unsub())
+    unsubscribers = []
+}
+
+let receiveUnsubscribers: (() => void)[] = []
+
+export function startSrcMixMidiReceive() {
+    stopSrcMixMidiReceive()
+
+    for (const { field, ctrl } of levelMappings) {
+        const id = cc.subscribe((voiceGroupIndex: number, midiValue: number) => {
+            const value = midiValue / 127
+            withMidiReceive(() => {
+                voiceGroupStores[voiceGroupIndex].getState().set(state => {
+                    state.srcMix[field] = value
+                })
+            })
+        }, ctrl)
+        receiveUnsubscribers.push(() => cc.unsubscribe(ctrl, id))
+    }
+
+    for (const { field, ctrl } of outMappings) {
+        const id = button.subscribe((voiceGroupIndex: number, midiValue: number) => {
+            const value = ctrl.values.indexOf(midiValue)
+            if (value < 0) return
+            withMidiReceive(() => {
+                voiceGroupStores[voiceGroupIndex].getState().set(state => {
+                    state.srcMix[field] = value
+                })
+            })
+        }, ctrl)
+        receiveUnsubscribers.push(() => button.unsubscribe(ctrl, id))
+    }
+}
+
+export function stopSrcMixMidiReceive() {
+    receiveUnsubscribers.forEach(unsub => unsub())
+    receiveUnsubscribers = []
+}

--- a/src/store/patchStore.ts
+++ b/src/store/patchStore.ts
@@ -101,6 +101,12 @@ export interface SrcMixState {
     levelNoise: number
     levelRingMod: number
     levelExtAudio: number
+    outOsc1: number
+    outOsc2: number
+    outOsc3: number
+    outNoise: number
+    outRingMod: number
+    outExtAudio: number
 }
 
 export interface FxState {
@@ -330,6 +336,12 @@ export const defaultVoiceGroupPatch = (): VoiceGroupPatch => ({
         levelNoise: 0,
         levelRingMod: 0,
         levelExtAudio: 0,
+        outOsc1: 0,
+        outOsc2: 0,
+        outOsc3: 0,
+        outNoise: 0,
+        outRingMod: 0,
+        outExtAudio: 0,
     },
     fx: {
         distortion: {


### PR DESCRIPTION
## Summary
- Add output routing fields (`outOsc1`..`outExtAudio`) to `SrcMixState` in patchStore
- Replace `ctrlGroup`/`ctrl` Redux pattern with `usePot` (levels with `dbLevelResponseMapper`) and `useButton` (output routing) hooks
- Add MIDI send/receive for 6 CC level pots and 6 button output routing params
- 14 new tests covering level CC and button MIDI send/receive

## Notes
- Level pots use `dbLevelResponseMapper` for UI display (dB curve), but MIDI encoding is linear 0-127 matching 0-1 store range
- Output routing buttons have 4 values: Off / A / B / Both

## Test plan
- [x] All 167 tests pass, no regressions
- [ ] Verify level pots respond with dB curve in UI
- [ ] Verify output routing buttons cycle through Off/A/B/Both
- [ ] Verify MIDI send/receive for levels and routing

🤖 Generated with [Claude Code](https://claude.com/claude-code)