### PR TITLE
Wire FX and Keyboard Controls to Zustand with MIDI

### DIFF
--- a/src/__tests__/store/fxKbdMidi.test.ts
+++ b/src/__tests__/store/fxKbdMidi.test.ts
@@ -1,0 +1,137 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+
+vi.mock('../../synthcore/synthcoreMiddleware', () => ({
+    synthcoreMiddleware: () => (next: any) => (action: any) => next(action),
+}))
+
+import { cc, button } from '../../midi/midibus'
+import { voiceGroupStores, createPatchStore } from '../../store/patchStore'
+import fxControllers from '../../synthcore/modules/fx/fxControllers'
+import kbdControllers from '../../synthcore/modules/kbd/kbdControllers'
+import { buttonMidiValues } from '../../midi/buttonMidiValues'
+import {
+    startFxKbdMidiSend,
+    stopFxKbdMidiSend,
+    startFxKbdMidiReceive,
+    stopFxKbdMidiReceive,
+} from '../../store/midi/fxKbdMidi'
+
+const VG = 0
+
+function getState() {
+    return voiceGroupStores[VG].getState()
+}
+
+function resetStore() {
+    const fresh = createPatchStore()
+    voiceGroupStores[VG].getState().loadPatch(fresh.getState().getPatch())
+}
+
+describe('FX/Kbd MIDI receive', () => {
+    beforeEach(() => {
+        resetStore()
+        startFxKbdMidiReceive()
+    })
+
+    afterEach(() => {
+        stopFxKbdMidiReceive()
+    })
+
+    it('sets distortion drive from CC', () => {
+        cc.publish(VG, fxControllers.DISTORTION.DRIVE.cc, 80)
+        expect(getState().fx.distortion.drive).toBeCloseTo(80 / 127, 2)
+    })
+
+    it('sets bit crusher bits from CC', () => {
+        cc.publish(VG, fxControllers.BIT_CRUSHER.BITS.cc, 64)
+        expect(getState().fx.bitCrusher.bits).toBeCloseTo(64 / 127, 2)
+    })
+
+    it('sets kbd portamento from CC', () => {
+        cc.publish(VG, kbdControllers.PORTAMENTO.cc, 100)
+        expect(getState().kbd.portamento).toBeCloseTo(100 / 127, 2)
+    })
+
+    it('sets distortion out from button MIDI', () => {
+        button.publish(VG, buttonMidiValues.DISTORTION_OUT_B)
+        expect(getState().fx.distortion.out).toBe(2)
+    })
+
+    it('sets bit crusher in from button MIDI', () => {
+        button.publish(VG, buttonMidiValues.BIT_CRUSHER_IN_A)
+        expect(getState().fx.bitCrusher.in).toBe(0)
+    })
+
+    it('sets kbd mode from button MIDI', () => {
+        button.publish(VG, buttonMidiValues.KBD_MODE_UNISON)
+        expect(getState().kbd.mode).toBe(1)
+    })
+
+    it('sets kbd transpose from button MIDI', () => {
+        button.publish(VG, buttonMidiValues.TRANSPOSE_POS_2)
+        expect(getState().kbd.transpose).toBe(4)
+    })
+
+    it('sets kbd hold from button MIDI', () => {
+        button.publish(VG, buttonMidiValues.KBD_HOLD_ON)
+        expect(getState().kbd.hold).toBe(1)
+    })
+})
+
+describe('FX/Kbd MIDI send', () => {
+    let sentCC: { ccNum: number, value: number }[] = []
+    let sentButtons: { ctrl: any, value: number }[] = []
+    const origCCSend = cc.send
+    const origButtonSend = button.send
+
+    beforeEach(() => {
+        resetStore()
+        sentCC = []
+        sentButtons = []
+        cc.send = vi.fn((vg, ctrl, value) => {
+            sentCC.push({ ccNum: ctrl.cc, value })
+        }) as any
+        button.send = vi.fn((vg, ctrl, value) => {
+            sentButtons.push({ ctrl, value })
+        }) as any
+        startFxKbdMidiSend()
+    })
+
+    afterEach(() => {
+        stopFxKbdMidiSend()
+        cc.send = origCCSend
+        button.send = origButtonSend
+    })
+
+    it('sends distortion drive as CC', () => {
+        getState().set(s => { s.fx.distortion.drive = 0.6 })
+        const sent = sentCC.find(s => s.ccNum === fxControllers.DISTORTION.DRIVE.cc)
+        expect(sent).toBeDefined()
+        expect(sent!.value).toBe(Math.floor(127 * 0.6))
+    })
+
+    it('sends kbd portamento as CC', () => {
+        getState().set(s => { s.kbd.portamento = 0.3 })
+        const sent = sentCC.find(s => s.ccNum === kbdControllers.PORTAMENTO.cc)
+        expect(sent).toBeDefined()
+        expect(sent!.value).toBe(Math.floor(127 * 0.3))
+    })
+
+    it('sends distortion out as button MIDI', () => {
+        getState().set(s => { s.fx.distortion.out = 3 })
+        const sent = sentButtons.find(s => s.value === buttonMidiValues.DISTORTION_OUT_BOTH)
+        expect(sent).toBeDefined()
+    })
+
+    it('sends kbd transpose as button MIDI', () => {
+        getState().set(s => { s.kbd.transpose = 2 })
+        const sent = sentButtons.find(s => s.value === buttonMidiValues.TRANSPOSE_0)
+        expect(sent).toBeDefined()
+    })
+
+    it('sends kbd mode as button MIDI', () => {
+        getState().set(s => { s.kbd.mode = 2 })
+        const sent = sentButtons.find(s => s.value === buttonMidiValues.KBD_MODE_POLY)
+        expect(sent).toBeDefined()
+    })
+})

--- a/src/components/modules/KeyboardControls.tsx
+++ b/src/components/modules/KeyboardControls.tsx
@@ -2,18 +2,15 @@ import RotaryPot12 from '../pots/RotaryPot12'
 import RoundLedPushButton8 from '../buttons/RoundLedPushButton8'
 import RoundPushButton8 from '../buttons/RoundPushButton8'
 import Led from '../leds/Led'
-import React from 'react'
-import { ControllerGroupIds } from '../../synthcore/types'
-import kbdControllers from '../../synthcore/modules/kbd/kbdControllers'
-import { useAppSelector } from '../../synthcore/hooks'
-import { selectController } from '../../synthcore/modules/controllers/controllersReducer'
+import React, { useCallback } from 'react'
 import { ModuleBorder } from "../misc/ModuleBorder";
 import SubHeader from "../misc/SubHeader";
 import { ModuleProps } from "./types";
-import { POT_DISTANCE_M, POT_OFFSET_Y, ROW_HEIGHT } from "../../constants";
+import { POT_DISTANCE_M, POT_OFFSET_Y } from "../../constants";
 import "./KeyboardControls.scss"
-
-const ctrlGroup = ControllerGroupIds.KBD
+import { usePot, useButton, usePatchValue } from '../../store/hooks'
+import { voiceGroupStores } from '../../store/patchStore'
+import { useUiStore } from '../../store/uiStore'
 
 export const Transpose = ({ x, y, height, width }: ModuleProps) => {
     const ledDistance = 8
@@ -29,7 +26,24 @@ export const Transpose = ({ x, y, height, width }: ModuleProps) => {
 
     const row1 = y + POT_OFFSET_Y
 
-    const transpose = useAppSelector(selectController(kbdControllers.TRANSPOSE))
+    const transpose = usePatchValue(s => s.kbd.transpose)
+    const voiceGroupIndex = useUiStore(s => s.currentVoiceGroupIndex)
+
+    const transposeDown = useCallback(() => {
+        const store = voiceGroupStores[voiceGroupIndex].getState()
+        const current = store.kbd.transpose
+        if (current > 0) {
+            store.set(state => { state.kbd.transpose = current - 1 })
+        }
+    }, [voiceGroupIndex])
+
+    const transposeUp = useCallback(() => {
+        const store = voiceGroupStores[voiceGroupIndex].getState()
+        const current = store.kbd.transpose
+        if (current < 4) {
+            store.set(state => { state.kbd.transpose = current + 1 })
+        }
+    }, [voiceGroupIndex])
 
     return <>
         <ModuleBorder x={x} y={y} height={height} width={width} className="keyboard-controls-background"/>
@@ -38,10 +52,8 @@ export const Transpose = ({ x, y, height, width }: ModuleProps) => {
                    className="keyboard-controls-header"/>
 
         <RoundPushButton8 labelPosition="bottom-pot" x={col1} y={row1}
-                          label="Down" reverse
-                          loop={false}
-                          ctrlGroup={ctrlGroup}
-                          ctrl={kbdControllers.TRANSPOSE}
+                          label="Down"
+                          onButtonClick={transposeDown}
         />
 
         <Led x={col2} y={row1} label="-2" on={transpose === 0}/>
@@ -51,9 +63,7 @@ export const Transpose = ({ x, y, height, width }: ModuleProps) => {
         <Led x={col6} y={row1} label="2" on={transpose === 4}/>
         <RoundPushButton8 labelPosition="bottom-pot" x={col7} y={row1}
                           label="Up"
-                          loop={false}
-                          ctrlGroup={ctrlGroup}
-                          ctrl={kbdControllers.TRANSPOSE}
+                          onButtonClick={transposeUp}
         />
     </>
 }
@@ -67,6 +77,30 @@ export const Keyboard = ({ x, y, height, width }: ModuleProps) => {
     const col11 = col10 + 20
     const col12 = col11 + 45
 
+    const { displayValue: portValue, increment: portIncrement } = usePot(
+        s => s.kbd.portamento,
+        (s, v) => { s.kbd.portamento = v }
+    )
+    const { displayValue: detuneValue, increment: detuneIncrement } = usePot(
+        s => s.kbd.unisonDetune,
+        (s, v) => { s.kbd.unisonDetune = v }
+    )
+    const { value: holdValue, toggle: holdToggle } = useButton(
+        s => s.kbd.hold,
+        (s, v) => { s.kbd.hold = v },
+        2
+    )
+    const { value: chordValue, toggle: chordToggle } = useButton(
+        s => s.kbd.chord,
+        (s, v) => { s.kbd.chord = v },
+        2
+    )
+    const { value: modeValue, toggle: modeToggle } = useButton(
+        s => s.kbd.mode,
+        (s, v) => { s.kbd.mode = v },
+        3
+    )
+
     return <>
         <ModuleBorder x={x} y={y} height={height} width={width} className="keyboard-controls-background"/>
         <SubHeader label="Keyboard" labelPosition="center" labelWidth={22} labelBackgroundOn={false}
@@ -74,29 +108,29 @@ export const Keyboard = ({ x, y, height, width }: ModuleProps) => {
                    className="keyboard-controls-header"/>
 
         <RotaryPot12 x={col8} y={row1} ledMode="single" label="Portamento"
-                     ctrlGroup={ctrlGroup}
-                     ctrl={kbdControllers.PORTAMENTO}
+                     value={portValue}
+                     onValueIncrement={portIncrement}
         />
 
         <RoundLedPushButton8 labelPosition="bottom-pot" x={col9} y={row1} label="Hold"
-                             ctrlGroup={ctrlGroup}
-                             ctrl={kbdControllers.HOLD}
+                             value={holdValue}
+                             onButtonClick={holdToggle}
         />
 
         <RoundLedPushButton8 labelPosition="bottom-pot" x={col10} y={row1} label="Chord"
-                             ctrlGroup={ctrlGroup}
-                             ctrl={kbdControllers.CHORD}
+                             value={chordValue}
+                             onButtonClick={chordToggle}
         />
 
         <RoundPushButton8 labelPosition="bottom-pot" x={col11} y={row1} label="Mode" ledCount={3} ledPosition="right"
                           ledLabels={['Solo', 'Unison', 'Poly']}
-                          ctrlGroup={ctrlGroup}
-                          ctrl={kbdControllers.MODE}
+                          value={modeValue}
+                          onButtonClick={modeToggle}
         />
 
         <RotaryPot12 x={col12} y={row1} ledMode="single" label="Unison detune"
-                     ctrlGroup={ctrlGroup}
-                     ctrl={kbdControllers.UNISON_DETUNE}
+                     value={detuneValue}
+                     onValueIncrement={detuneIncrement}
         />
     </>
 }

--- a/src/components/modules/left2/Effects.tsx
+++ b/src/components/modules/left2/Effects.tsx
@@ -1,7 +1,5 @@
 import React from 'react'
 import RoundPushButton8 from '../../buttons/RoundPushButton8'
-import { ControllerGroupIds } from '../../../synthcore/types'
-import fxControllers from '../../../synthcore/modules/fx/fxControllers'
 import RotaryPot12 from "../../pots/RotaryPot12";
 import SubHeader from "../../misc/SubHeader";
 import {
@@ -12,14 +10,48 @@ import {
     POT_OFFSET_Y,
     ROW_HEIGHT,
 } from "../../../constants";
-import { SHOW_CUT } from "../../../config";
 import { ModuleProps } from "../types";
 import { ModuleBorder } from "../../misc/ModuleBorder";
 import "../Modules.scss"
-
-const ctrlGroup = ControllerGroupIds.FX
+import { usePot, useButton } from '../../../store/hooks'
 
 const Effects = ({ x, y, height, width }: ModuleProps) => {
+    const { displayValue: driveValue, increment: driveIncrement } = usePot(
+        s => s.fx.distortion.drive,
+        (s, v) => { s.fx.distortion.drive = v }
+    )
+    const { displayValue: levelValue, increment: levelIncrement } = usePot(
+        s => s.fx.distortion.level,
+        (s, v) => { s.fx.distortion.level = v }
+    )
+    const { value: distInValue, toggle: distInToggle } = useButton(
+        s => s.fx.distortion.in,
+        (s, v) => { s.fx.distortion.in = v },
+        2
+    )
+    const { value: distOutValue, toggle: distOutToggle } = useButton(
+        s => s.fx.distortion.out,
+        (s, v) => { s.fx.distortion.out = v },
+        4
+    )
+    const { displayValue: bitsValue, increment: bitsIncrement } = usePot(
+        s => s.fx.bitCrusher.bits,
+        (s, v) => { s.fx.bitCrusher.bits = v }
+    )
+    const { displayValue: rateValue, increment: rateIncrement } = usePot(
+        s => s.fx.bitCrusher.rate,
+        (s, v) => { s.fx.bitCrusher.rate = v }
+    )
+    const { value: crushInValue, toggle: crushInToggle } = useButton(
+        s => s.fx.bitCrusher.in,
+        (s, v) => { s.fx.bitCrusher.in = v },
+        2
+    )
+    const { value: crushOutValue, toggle: crushOutToggle } = useButton(
+        s => s.fx.bitCrusher.out,
+        (s, v) => { s.fx.bitCrusher.out = v },
+        4
+    )
 
     const row1 = y
     const row2 = row1 + POT_OFFSET_Y
@@ -30,10 +62,7 @@ const Effects = ({ x, y, height, width }: ModuleProps) => {
     const col3 = col1 + POT_DISTANCE_L
     const col4 = col3 + POT_DISTANCE_S
 
-    const center = x + POT_DISTANCE_L
-
     return <>
-        {/*!SHOW_CUT && <rect x={x} y={y} width="131" height={2 * ROW_HEIGHT} className="module-background"/>*/}
         <ModuleBorder x={x} y={y} height={height} width={width} className="audio-elements-border"/>
         <SubHeader
             x={x} y={row1}
@@ -47,8 +76,8 @@ const Effects = ({ x, y, height, width }: ModuleProps) => {
             label="Crush" labelWidth={20} labelPosition="center" padding="right"/>
 
         <RotaryPot12 ledMode="multi" label="Drive" x={col1} y={row2}
-                     ctrlGroup={ctrlGroup}
-                     ctrl={fxControllers.DISTORTION.DRIVE}
+                     value={driveValue}
+                     onValueIncrement={driveIncrement}
         />
 
         <RoundPushButton8 x={col2} y={row2 + DUAL_LED_BUTTON_W_LABEL_OFFSET_Y}
@@ -57,13 +86,13 @@ const Effects = ({ x, y, height, width }: ModuleProps) => {
                           ledRingColors={['#00bfa6', '#ff8700']}
                           label="From"
                           labelPosition="bottom"
-                          ctrlGroup={ctrlGroup}
-                          ctrl={fxControllers.DISTORTION.IN}
+                          value={distInValue}
+                          onButtonClick={distInToggle}
         />
 
         <RotaryPot12 ledMode="multi" label="Level" x={col1} y={row3}
-                     ctrlGroup={ctrlGroup}
-                     ctrl={fxControllers.DISTORTION.LEVEL}
+                     value={levelValue}
+                     onValueIncrement={levelIncrement}
         />
 
         <RoundPushButton8 x={col2} y={row3 + DUAL_LED_BUTTON_W_LABEL_OFFSET_Y}
@@ -72,15 +101,15 @@ const Effects = ({ x, y, height, width }: ModuleProps) => {
                           ledRingColors={['#00bfa6', '#ff8700']}
                           label="To"
                           labelPosition="bottom"
-                          ctrlGroup={ctrlGroup}
                           hasOff
-                          ctrl={fxControllers.DISTORTION.OUT}
+                          value={distOutValue}
+                          onButtonClick={distOutToggle}
         />
 
 
         <RotaryPot12 ledMode="single" ledCount={12} label="Bits" x={col3} y={row2}
-                     ctrlGroup={ctrlGroup}
-                     ctrl={fxControllers.BIT_CRUSHER.BITS}
+                     value={bitsValue}
+                     onValueIncrement={bitsIncrement}
         />
 
         <RoundPushButton8 x={col4} y={row2 + DUAL_LED_BUTTON_W_LABEL_OFFSET_Y}
@@ -89,26 +118,14 @@ const Effects = ({ x, y, height, width }: ModuleProps) => {
                           ledRingColors={['#00bfa6', '#ff8700']}
                           label="From"
                           labelPosition="bottom"
-                          ctrlGroup={ctrlGroup}
-                          ctrl={fxControllers.BIT_CRUSHER.IN}
+                          value={crushInValue}
+                          onButtonClick={crushInToggle}
         />
 
         <RotaryPot12 ledMode="single" label="Rate" x={col3} y={row3}
-                     ctrlGroup={ctrlGroup}
-                     ctrl={fxControllers.BIT_CRUSHER.RATE}
+                     value={rateValue}
+                     onValueIncrement={rateIncrement}
         />
-
-        {/*        <RoundLedPushButton8 x={col4} y={row2 + 3}
-                             label="Recon"
-                             labelPosition="bottom"
-                             ctrlGroup={ctrlGroup}
-                             ctrl={fxControllers.BIT_CRUSHER.RECON}
-        />
-
-        <RotaryPot12 ledMode="multi" label="Level" x={col4} y={row3}
-                     ctrlGroup={ctrlGroup}
-                     ctrl={fxControllers.BIT_CRUSHER.LEVEL}
-        />*/}
 
         <RoundPushButton8 x={col4} y={row3 + DUAL_LED_BUTTON_W_LABEL_OFFSET_Y}
                           ledPosition="top-horizontal-no-label"
@@ -116,9 +133,9 @@ const Effects = ({ x, y, height, width }: ModuleProps) => {
                           ledRingColors={['#00bfa6', '#ff8700']}
                           label="To"
                           labelPosition="bottom"
-                          ctrlGroup={ctrlGroup}
                           hasOff
-                          ctrl={fxControllers.BIT_CRUSHER.OUT}
+                          value={crushOutValue}
+                          onButtonClick={crushOutToggle}
         />
     </>
 }

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -10,12 +10,15 @@ import { startEnvelopeMidiSend } from './store/midi/envMidiSend'
 import { startEnvelopeMidiReceive } from './store/midi/envMidiReceive'
 import { startSimpleButtonMidiSend } from './store/midi/simpleButtonMidiSend'
 import { startSimpleButtonMidiReceive } from './store/midi/simpleButtonMidiReceive'
+import { startFxKbdMidiSend, startFxKbdMidiReceive } from './store/midi/fxKbdMidi'
 
 midiApi.initReceive()
 startEnvelopeMidiSend()
 startEnvelopeMidiReceive()
 startSimpleButtonMidiSend()
 startSimpleButtonMidiReceive()
+startFxKbdMidiSend()
+startFxKbdMidiReceive()
 
 const root = ReactDOM.createRoot(
   document.getElementById('root') as HTMLElement

--- a/src/midi/midibus.ts
+++ b/src/midi/midibus.ts
@@ -50,6 +50,7 @@ const midiConfig = {
         '505084812', // Steinberg UR22C Port 1
         '-1515485747', // Steinberg UR22C Port 1
         'vdYvBfG28aCbHM9U6S3RAB8EwW4YMLWpA6pdZ0Eq9tM=', // Steinberg UR22C Port 1 Firefox
+        'l0+mSOnHhAPqGL1UqdZwvtLsPg6lMbdKY6RNwwwdWzQ=', // Steinberg UR22C Port 1 Firefox
         //'-762163153', // Steinberg UR22C Port 2
 
     ],
@@ -59,6 +60,7 @@ const midiConfig = {
         '-746118775', // Steinberg UR22C Port 1
         '979568398', // Steinberg UR22C Port 1
         'vdYvBfG28aCbHM9U6S3RAB8EwW4YMLWpA6pdZ0Eq9tM=', // Steinberg UR22C Port 1 Firefox
+        'l0+mSOnHhAPqGL1UqdZwvtLsPg6lMbdKY6RNwwwdWzQ=', // Steinberg UR22C Port 1 Firefox
         // '298365873', // Steinberg UR22C Port 2
     ],
     sysexAddr: [1, 2, 3],

--- a/src/store/midi/fxKbdMidi.ts
+++ b/src/store/midi/fxKbdMidi.ts
@@ -1,0 +1,119 @@
+import { voiceGroupStores, VoiceGroupPatch, FxState, KbdState } from '../patchStore'
+import { cc, button } from '../../midi/midibus'
+import { ControllerConfigCC, ControllerConfigButton } from '../../midi/types'
+import fxControllers from '../../synthcore/modules/fx/fxControllers'
+import kbdControllers from '../../synthcore/modules/kbd/kbdControllers'
+import { isMidiReceiving, withMidiReceive } from './midiGuard'
+
+interface CCMapping {
+    selector: (state: VoiceGroupPatch) => number
+    mutator: (state: VoiceGroupPatch, value: number) => void
+    ctrl: ControllerConfigCC
+}
+
+interface ButtonMapping {
+    selector: (state: VoiceGroupPatch) => number
+    mutator: (state: VoiceGroupPatch, value: number) => void
+    ctrl: ControllerConfigButton
+}
+
+const ccMappings: CCMapping[] = [
+    { selector: s => s.fx.distortion.drive, mutator: (s, v) => { s.fx.distortion.drive = v }, ctrl: fxControllers.DISTORTION.DRIVE },
+    { selector: s => s.fx.distortion.level, mutator: (s, v) => { s.fx.distortion.level = v }, ctrl: fxControllers.DISTORTION.LEVEL },
+    { selector: s => s.fx.bitCrusher.bits, mutator: (s, v) => { s.fx.bitCrusher.bits = v }, ctrl: fxControllers.BIT_CRUSHER.BITS },
+    { selector: s => s.fx.bitCrusher.rate, mutator: (s, v) => { s.fx.bitCrusher.rate = v }, ctrl: fxControllers.BIT_CRUSHER.RATE },
+    { selector: s => s.fx.bitCrusher.level, mutator: (s, v) => { s.fx.bitCrusher.level = v }, ctrl: fxControllers.BIT_CRUSHER.LEVEL },
+    { selector: s => s.kbd.portamento, mutator: (s, v) => { s.kbd.portamento = v }, ctrl: kbdControllers.PORTAMENTO },
+    { selector: s => s.kbd.unisonDetune, mutator: (s, v) => { s.kbd.unisonDetune = v }, ctrl: kbdControllers.UNISON_DETUNE },
+]
+
+const buttonMappings: ButtonMapping[] = [
+    { selector: s => s.fx.distortion.in, mutator: (s, v) => { s.fx.distortion.in = v }, ctrl: fxControllers.DISTORTION.IN },
+    { selector: s => s.fx.distortion.out, mutator: (s, v) => { s.fx.distortion.out = v }, ctrl: fxControllers.DISTORTION.OUT },
+    { selector: s => s.fx.bitCrusher.in, mutator: (s, v) => { s.fx.bitCrusher.in = v }, ctrl: fxControllers.BIT_CRUSHER.IN },
+    { selector: s => s.fx.bitCrusher.out, mutator: (s, v) => { s.fx.bitCrusher.out = v }, ctrl: fxControllers.BIT_CRUSHER.OUT },
+    { selector: s => s.kbd.hold, mutator: (s, v) => { s.kbd.hold = v }, ctrl: kbdControllers.HOLD },
+    { selector: s => s.kbd.chord, mutator: (s, v) => { s.kbd.chord = v }, ctrl: kbdControllers.CHORD },
+    { selector: s => s.kbd.mode, mutator: (s, v) => { s.kbd.mode = v }, ctrl: kbdControllers.MODE },
+    { selector: s => s.kbd.transpose, mutator: (s, v) => { s.kbd.transpose = v }, ctrl: kbdControllers.TRANSPOSE },
+    { selector: s => s.kbd.voiceStealing, mutator: (s, v) => { s.kbd.voiceStealing = v }, ctrl: kbdControllers.VOICE_STEALING },
+]
+
+let sendUnsubscribers: (() => void)[] = []
+
+export function startFxKbdMidiSend() {
+    stopFxKbdMidiSend()
+
+    voiceGroupStores.forEach((store, voiceGroupIndex) => {
+        let prevState = store.getState()
+
+        const unsub = store.subscribe((state) => {
+            if (isMidiReceiving()) {
+                prevState = state
+                return
+            }
+
+            const prev = prevState
+            prevState = state
+
+            for (const m of ccMappings) {
+                const current = m.selector(state)
+                const previous = m.selector(prev)
+                if (current !== previous) {
+                    cc.send(voiceGroupIndex, m.ctrl, Math.floor(127 * current))
+                }
+            }
+
+            for (const m of buttonMappings) {
+                const current = m.selector(state)
+                const previous = m.selector(prev)
+                if (current !== previous) {
+                    button.send(voiceGroupIndex, m.ctrl, m.ctrl.values[current])
+                }
+            }
+        })
+
+        sendUnsubscribers.push(unsub)
+    })
+}
+
+export function stopFxKbdMidiSend() {
+    sendUnsubscribers.forEach(unsub => unsub())
+    sendUnsubscribers = []
+}
+
+let receiveUnsubscribers: (() => void)[] = []
+
+export function startFxKbdMidiReceive() {
+    stopFxKbdMidiReceive()
+
+    for (const m of ccMappings) {
+        const id = cc.subscribe((voiceGroupIndex: number, midiValue: number) => {
+            const value = midiValue / 127
+            withMidiReceive(() => {
+                voiceGroupStores[voiceGroupIndex].getState().set(state => {
+                    m.mutator(state, value)
+                })
+            })
+        }, m.ctrl)
+        receiveUnsubscribers.push(() => cc.unsubscribe(m.ctrl, id))
+    }
+
+    for (const m of buttonMappings) {
+        const id = button.subscribe((voiceGroupIndex: number, midiValue: number) => {
+            const value = m.ctrl.values.indexOf(midiValue)
+            if (value < 0) return
+            withMidiReceive(() => {
+                voiceGroupStores[voiceGroupIndex].getState().set(state => {
+                    m.mutator(state, value)
+                })
+            })
+        }, m.ctrl)
+        receiveUnsubscribers.push(() => button.unsubscribe(m.ctrl, id))
+    }
+}
+
+export function stopFxKbdMidiReceive() {
+    receiveUnsubscribers.forEach(unsub => unsub())
+    receiveUnsubscribers = []
+}


### PR DESCRIPTION
## Summary
- Wire Distortion (2 CC pots + in/out buttons) and BitCrusher (3 CC pots + in/out buttons) to Zustand
- Wire Keyboard Controls: Portamento and Unison Detune pots, Hold/Chord/Mode/Transpose buttons
- Remove Redux dependency from Keyboard's Transpose component — now reads via `usePatchValue` instead of `useAppSelector(selectController(...))`
- Transpose up/down buttons use custom callbacks for bounded increment/decrement
- 13 new tests covering FX and Keyboard MIDI send/receive

## Test plan
- [x] All 166 tests pass, no regressions
- [ ] Verify Distortion drive/level pots and in/out buttons respond in UI
- [ ] Verify BitCrusher bits/rate/level pots and in/out buttons respond in UI
- [ ] Verify Keyboard portamento/detune pots, hold/chord/mode buttons
- [ ] Verify Transpose up/down buttons with LED display
- [ ] Verify MIDI send/receive for all parameters

🤖 Generated with [Claude Code](https://claude.com/claude-code)