### PR TITLE
Wire oscillators (DCO1, DCO2, VCO) to Zustand with MIDI

### DIFF
--- a/src/__tests__/store/oscMidi.test.ts
+++ b/src/__tests__/store/oscMidi.test.ts
@@ -1,0 +1,136 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+
+vi.mock('../../synthcore/synthcoreMiddleware', () => ({
+    synthcoreMiddleware: () => (next: any) => (action: any) => next(action),
+}))
+
+import { cc, button } from '../../midi/midibus'
+import { voiceGroupStores, createPatchStore } from '../../store/patchStore'
+import oscControllers from '../../synthcore/modules/osc/oscControllers'
+import { buttonMidiValues } from '../../midi/buttonMidiValues'
+import {
+    startOscMidiSend,
+    stopOscMidiSend,
+    startOscMidiReceive,
+    stopOscMidiReceive,
+} from '../../store/midi/oscMidi'
+
+const VG = 0
+
+function getState() {
+    return voiceGroupStores[VG].getState()
+}
+
+function resetStore() {
+    const fresh = createPatchStore()
+    voiceGroupStores[VG].getState().loadPatch(fresh.getState().getPatch())
+}
+
+describe('oscillator MIDI receive', () => {
+    beforeEach(() => {
+        resetStore()
+        startOscMidiReceive()
+    })
+
+    afterEach(() => {
+        stopOscMidiReceive()
+    })
+
+    it('sets DCO1 note from CC', () => {
+        cc.publish(VG, oscControllers.DCO1.NOTE.cc, 80)
+        expect(getState().oscillators[0].note).toBeCloseTo(80 / 127, 2)
+    })
+
+    it('sets DCO2 waveform from CC', () => {
+        cc.publish(VG, oscControllers.DCO2.WAVEFORM.cc, 64)
+        expect(getState().oscillators[1].waveform).toBeCloseTo(64 / 127, 2)
+    })
+
+    it('sets VCO fmAmt from CC', () => {
+        cc.publish(VG, oscControllers.VCO.FM_AMT.cc, 100)
+        expect(getState().oscillators[2].fmAmt).toBeCloseTo(100 / 127, 2)
+    })
+
+    it('sets DCO1 sync from button MIDI', () => {
+        button.publish(VG, buttonMidiValues.OSC1_SYNC_HARD)
+        expect(getState().oscillators[0].sync).toBe(1)
+    })
+
+    it('sets DCO1 mode from button MIDI', () => {
+        button.publish(VG, buttonMidiValues.OSC1_MODE_PCM)
+        expect(getState().oscillators[0].mode).toBe(2)
+    })
+
+    it('sets DCO2 wheel on from button MIDI', () => {
+        button.publish(VG, buttonMidiValues.OSC2_WHEEL_ON)
+        expect(getState().oscillators[1].wheel).toBe(1)
+    })
+
+    it('sets VCO sync src from button MIDI', () => {
+        button.publish(VG, buttonMidiValues.OSC3_SYNC_SRC_OSC_2)
+        expect(getState().oscillators[2].syncSrc).toBe(1)
+    })
+
+    it('sets VCO fm mode from button MIDI', () => {
+        button.publish(VG, buttonMidiValues.OSC3_FM_MODE_LOG)
+        expect(getState().oscillators[2].fmMode).toBe(2)
+    })
+})
+
+describe('oscillator MIDI send', () => {
+    let sentCC: { ccNum: number, value: number }[] = []
+    let sentButtons: { ctrl: any, value: number }[] = []
+    const origCCSend = cc.send
+    const origButtonSend = button.send
+
+    beforeEach(() => {
+        resetStore()
+        sentCC = []
+        sentButtons = []
+        cc.send = vi.fn((vg, ctrl, value) => {
+            sentCC.push({ ccNum: ctrl.cc, value })
+        }) as any
+        button.send = vi.fn((vg, ctrl, value) => {
+            sentButtons.push({ ctrl, value })
+        }) as any
+        startOscMidiSend()
+    })
+
+    afterEach(() => {
+        stopOscMidiSend()
+        cc.send = origCCSend
+        button.send = origButtonSend
+    })
+
+    it('sends DCO1 note change as CC', () => {
+        getState().set(s => { s.oscillators[0].note = 0.5 })
+        const sent = sentCC.find(s => s.ccNum === oscControllers.DCO1.NOTE.cc)
+        expect(sent).toBeDefined()
+        expect(sent!.value).toBe(Math.floor(127 * 0.5))
+    })
+
+    it('sends VCO pw change as CC', () => {
+        getState().set(s => { s.oscillators[2].pw = 0.3 })
+        const sent = sentCC.find(s => s.ccNum === oscControllers.VCO.PW.cc)
+        expect(sent).toBeDefined()
+        expect(sent!.value).toBe(Math.floor(127 * 0.3))
+    })
+
+    it('sends DCO1 sync change as button MIDI', () => {
+        getState().set(s => { s.oscillators[0].sync = 2 })
+        const sent = sentButtons.find(s => s.value === buttonMidiValues.OSC1_SYNC_METAL)
+        expect(sent).toBeDefined()
+    })
+
+    it('sends VCO ext CV change as button MIDI', () => {
+        getState().set(s => { s.oscillators[2].extCv = 1 })
+        const sent = sentButtons.find(s => s.value === buttonMidiValues.OSC3_EXT_CV_ON)
+        expect(sent).toBeDefined()
+    })
+
+    it('does not send when value unchanged', () => {
+        const defaultNote = getState().oscillators[0].note
+        getState().set(s => { s.oscillators[0].note = defaultNote })
+        expect(sentCC.find(s => s.ccNum === oscControllers.DCO1.NOTE.cc)).toBeUndefined()
+    })
+})

--- a/src/components/modules/left2/DCO1.tsx
+++ b/src/components/modules/left2/DCO1.tsx
@@ -1,17 +1,14 @@
-import React from 'react'
+import React, { useCallback } from 'react'
 import RotaryPot21 from '../../pots/RotaryPot21'
 import RotaryPot12 from '../../pots/RotaryPot12'
 import RoundPushButton8 from '../../buttons/RoundPushButton8'
 import RoundLedPushButton8 from '../../buttons/RoundLedPushButton8'
-import { ControllerGroupIds } from '../../../synthcore/types'
-import oscControllers from '../../../synthcore/modules/osc/oscControllers'
 import SubHeader from "../../misc/SubHeader";
 import {
     DUAL_LED_BUTTON_W_LABEL_OFFSET_Y, POT_DISTANCE_L,
     POT_DISTANCE_M, POT_DISTANCE_S, POT_OFFSET_Y,
     ROW_HEIGHT,
 } from "../../../constants";
-import { SHOW_CUT } from "../../../config";
 import { VerticalDividerLine } from "../../misc/VerticalDividerLine";
 import { ModuleBorder } from "../../misc/ModuleBorder";
 import { ModuleProps } from "../types";
@@ -24,8 +21,37 @@ import { PulseRight } from "../../images/PulseRight";
 import { PwIconsRing } from "./PwIconsRing";
 import { SawRight } from "../../images/SawRight";
 import { Square } from "../../images/Square";
+import { usePot, useButton } from '../../../store/hooks'
+import { VoiceGroupPatch, voiceGroupStores } from '../../../store/patchStore'
+import { useUiStore } from '../../../store/uiStore'
 
-const ctrlGroup = ControllerGroupIds.OSC
+const OSC = 0
+
+const OscTogglePot = ({ x, y, label, selector, mutator }: {
+    x: number, y: number, label: string,
+    selector: (s: VoiceGroupPatch) => number,
+    mutator: (s: VoiceGroupPatch, v: number) => void,
+}) => {
+    const voiceGroupIndex = useUiStore(s => s.currentVoiceGroupIndex)
+    const { value } = useButton(selector, mutator, 2)
+    const onIncrement = useCallback((delta: number) => {
+        voiceGroupStores[voiceGroupIndex].getState().set(state => {
+            mutator(state, delta > 0 ? 1 : 0)
+        })
+    }, [voiceGroupIndex, mutator])
+    return <RotaryPot12 x={x} y={y} label={label}
+                        value={value} onValueIncrement={onIncrement} />
+}
+
+const OscPot = ({ x, y, label, ledMode = 'single' as const, selector, mutator }: {
+    x: number, y: number, label: string, ledMode?: 'single' | 'multi',
+    selector: (s: VoiceGroupPatch) => number,
+    mutator: (s: VoiceGroupPatch, v: number) => void,
+}) => {
+    const { displayValue, increment } = usePot(selector, mutator)
+    return <RotaryPot12 x={x} y={y} ledMode={ledMode} label={label}
+                        value={displayValue} onValueIncrement={increment} />
+}
 
 const DCO1 = ({ x, y, height, width }: ModuleProps) => {
 
@@ -49,6 +75,36 @@ const DCO1 = ({ x, y, height, width }: ModuleProps) => {
     const pwLeftPos = rotateAround(upPos, [x, y], -125)
     const pwRightPos = rotateAround(upPos, [x, y], 125)
 
+    const { value: modeValue, toggle: modeToggle } = useButton(
+        s => s.oscillators[OSC].mode,
+        (s, v) => { s.oscillators[OSC].mode = v },
+        3
+    )
+    const { value: syncValue, toggle: syncToggle } = useButton(
+        s => s.oscillators[OSC].sync,
+        (s, v) => { s.oscillators[OSC].sync = v },
+        3
+    )
+    const { value: sawInvValue, toggle: sawInvToggle } = useButton(
+        s => s.oscillators[OSC].sawInv,
+        (s, v) => { s.oscillators[OSC].sawInv = v },
+        2
+    )
+    const { value: preFilterSineValue, toggle: preFilterSineToggle } = useButton(
+        s => s.oscillators[OSC].preFilterSine,
+        (s, v) => { s.oscillators[OSC].preFilterSine = v },
+        2
+    )
+    const { value: subWaveValue, toggle: subWaveToggle } = useButton(
+        s => s.oscillators[OSC].subWave,
+        (s, v) => { s.oscillators[OSC].subWave = v },
+        2
+    )
+    const { displayValue: wfValue, increment: wfIncrement } = usePot(
+        s => s.oscillators[OSC].waveform,
+        (s, v) => { s.oscillators[OSC].waveform = v }
+    )
+
     return <>
         {/*!SHOW_CUT && <rect x={x-52.5} y={y} width="105" height={130 - ROW_SPACING} className="module-background"/>*/}
         <ModuleBorder x={x} y={y} height={height} width={width} className="audio-elements-border"/>
@@ -59,30 +115,30 @@ const DCO1 = ({ x, y, height, width }: ModuleProps) => {
         <RoundPushButton8 x={col1} y={topRow}
                           ledPosition="right" ledCount={3} ledLabels={['DCO', 'WT', 'PCM']}
                           label="Mode" labelPosition="bottom-pot"
-                          ctrlGroup={ctrlGroup}
-                          ctrl={oscControllers.DCO1.MODE}
+                          value={modeValue}
+                          onButtonClick={modeToggle}
         />
 
 
-        <RotaryPot12 x={col2} y={topRow} label="Keyboard"
-                     ctrlGroup={ctrlGroup}
-                     ctrl={oscControllers.DCO1.KBD}
+        <OscTogglePot x={col2} y={topRow} label="Keyboard"
+                      selector={s => s.oscillators[OSC].kbd}
+                      mutator={(s, v) => { s.oscillators[OSC].kbd = v }}
         />
 
-        <RotaryPot12 x={col3} y={topRow} label="LFO"
-                     ctrlGroup={ctrlGroup}
-                     ctrl={oscControllers.DCO1.LFO}
+        <OscTogglePot x={col3} y={topRow} label="LFO"
+                      selector={s => s.oscillators[OSC].lfo}
+                      mutator={(s, v) => { s.oscillators[OSC].lfo = v }}
         />
 
 
-        <RotaryPot12 x={col4} y={topRow} ledMode="single" label="Note"
-                     ctrlGroup={ctrlGroup}
-                     ctrl={oscControllers.DCO1.NOTE}
+        <OscPot x={col4} y={topRow} ledMode="single" label="Note"
+                selector={s => s.oscillators[OSC].note}
+                mutator={(s, v) => { s.oscillators[OSC].note = v }}
         />
 
-        <RotaryPot12 x={col4} y={bottomRow} ledMode="single" label="Detune"
-                     ctrlGroup={ctrlGroup}
-                     ctrl={oscControllers.DCO1.DETUNE}
+        <OscPot x={col4} y={bottomRow} ledMode="single" label="Detune"
+                selector={s => s.oscillators[OSC].detune}
+                mutator={(s, v) => { s.oscillators[OSC].detune = v }}
         />
 
 
@@ -90,30 +146,30 @@ const DCO1 = ({ x, y, height, width }: ModuleProps) => {
                           ledPosition="right" ledCount={2} ledLabels={['Hard', 'Metal']}
                           label="Sync" labelPosition="bottom-pot"
                           hasOff
-                          ctrlGroup={ctrlGroup}
-                          ctrl={oscControllers.DCO1.SYNC}
+                          value={syncValue}
+                          onButtonClick={syncToggle}
         />
 
-        <RotaryPot12 x={col3} y={bottomRow} label="Wheel"
-                     ctrlGroup={ctrlGroup}
-                     ctrl={oscControllers.DCO1.WHEEL}
+        <OscTogglePot x={col3} y={bottomRow} label="Wheel"
+                      selector={s => s.oscillators[OSC].wheel}
+                      mutator={(s, v) => { s.oscillators[OSC].wheel = v }}
         />
 
         <RoundLedPushButton8 x={col5} y={topRow} label="Inv saw" labelPosition="bottom"
-                             ctrlGroup={ctrlGroup}
-                             ctrl={oscControllers.DCO1.SAW_INV}
+                             value={sawInvValue}
+                             onButtonClick={sawInvToggle}
         />
 
         <RotaryPot21 x={col6} y={centerRow} ledMode="single" label="Waveform"
-                     ctrlGroup={ctrlGroup}
-                     ctrl={oscControllers.DCO1.WAVEFORM}
+                     value={wfValue}
+                     onValueIncrement={wfIncrement}
         />
 
         <WaveformIconsRing x={col6} y={centerRow}/>
 
         <RoundLedPushButton8 x={col7} y={topRow} label="Sine" labelPosition="bottom"
-                             ctrlGroup={ctrlGroup}
-                             ctrl={oscControllers.DCO1.PRE_FILTER_SINE}
+                             value={preFilterSineValue}
+                             onButtonClick={preFilterSineToggle}
         />
 
         <RoundPushButton8 x={col9} y={bottomRow + DUAL_LED_BUTTON_W_LABEL_OFFSET_Y}
@@ -122,23 +178,23 @@ const DCO1 = ({ x, y, height, width }: ModuleProps) => {
                               <SawRight x={0} y={0} width={3} height={2}/>,
         ]}
                           label="Sub wave" labelPosition="bottom"
-                          ctrlGroup={ctrlGroup}
-                          ctrl={oscControllers.DCO1.SUB_WAVE}
+                          value={subWaveValue}
+                          onButtonClick={subWaveToggle}
         />
 
-        <RotaryPot12 x={col8} y={topRow} ledMode="multi" label="Sub -1"
-                     ctrlGroup={ctrlGroup}
-                     ctrl={oscControllers.DCO1.SUB1}
+        <OscPot x={col8} y={topRow} ledMode="multi" label="Sub -1"
+                selector={s => s.oscillators[OSC].sub1}
+                mutator={(s, v) => { s.oscillators[OSC].sub1 = v }}
         />
 
-        <RotaryPot12 x={col8} y={bottomRow} ledMode="single" label="Pulse width"
-                     ctrlGroup={ctrlGroup}
-                     ctrl={oscControllers.DCO1.PW}
+        <OscPot x={col8} y={bottomRow} ledMode="single" label="Pulse width"
+                selector={s => s.oscillators[OSC].pw}
+                mutator={(s, v) => { s.oscillators[OSC].pw = v }}
         />
 
-        <RotaryPot12 x={col9} y={topRow} ledMode="multi" label="Sub -2"
-                     ctrlGroup={ctrlGroup}
-                     ctrl={oscControllers.DCO1.SUB2}
+        <OscPot x={col9} y={topRow} ledMode="multi" label="Sub -2"
+                selector={s => s.oscillators[OSC].sub2}
+                mutator={(s, v) => { s.oscillators[OSC].sub2 = v }}
         />
 
     </>

--- a/src/components/modules/left2/DCO2.tsx
+++ b/src/components/modules/left2/DCO2.tsx
@@ -1,10 +1,8 @@
-import React from 'react'
+import React, { useCallback } from 'react'
 import RotaryPot21 from '../../pots/RotaryPot21'
 import RotaryPot12 from '../../pots/RotaryPot12'
 import RoundPushButton8 from '../../buttons/RoundPushButton8'
 import RoundLedPushButton8 from '../../buttons/RoundLedPushButton8'
-import { ControllerGroupIds } from '../../../synthcore/types'
-import oscControllers from '../../../synthcore/modules/osc/oscControllers'
 import SubHeader from "../../misc/SubHeader";
 import {
     DUAL_LED_BUTTON_W_LABEL_OFFSET_Y,
@@ -14,7 +12,6 @@ import {
     POT_OFFSET_Y,
     ROW_HEIGHT,
 } from "../../../constants";
-import { SHOW_CUT } from "../../../config";
 import { VerticalDividerLine } from "../../misc/VerticalDividerLine";
 import { ModuleBorder } from "../../misc/ModuleBorder";
 import { ModuleProps } from "../types";
@@ -23,10 +20,69 @@ import { WaveformIconsRing } from "./WaveformIconsRing";
 import { PwIconsRing } from "./PwIconsRing";
 import { Square } from "../../images/Square";
 import { SawRight } from "../../images/SawRight";
+import { usePot, useButton } from '../../../store/hooks'
+import { VoiceGroupPatch, voiceGroupStores } from '../../../store/patchStore'
+import { useUiStore } from '../../../store/uiStore'
 
-const ctrlGroup = ControllerGroupIds.OSC
+const OSC = 1
+
+const OscPot = ({ x, y, label, ledMode = 'single' as const, selector, mutator }: {
+    x: number, y: number, label: string, ledMode?: 'single' | 'multi',
+    selector: (s: VoiceGroupPatch) => number,
+    mutator: (s: VoiceGroupPatch, v: number) => void,
+}) => {
+    const { displayValue, increment } = usePot(selector, mutator)
+    return <RotaryPot12 x={x} y={y} ledMode={ledMode} label={label}
+                        value={displayValue} onValueIncrement={increment} />
+}
+
+const OscTogglePot = ({ x, y, label, selector, mutator }: {
+    x: number, y: number, label: string,
+    selector: (s: VoiceGroupPatch) => number,
+    mutator: (s: VoiceGroupPatch, v: number) => void,
+}) => {
+    const voiceGroupIndex = useUiStore(s => s.currentVoiceGroupIndex)
+    const { value } = useButton(selector, mutator, 2)
+    const onIncrement = useCallback((delta: number) => {
+        voiceGroupStores[voiceGroupIndex].getState().set(state => {
+            mutator(state, delta > 0 ? 1 : 0)
+        })
+    }, [voiceGroupIndex, mutator])
+    return <RotaryPot12 x={x} y={y} label={label}
+                        value={value} onValueIncrement={onIncrement} />
+}
 
 const DCO2 = ({ x, y, height, width }: ModuleProps) => {
+
+    const { value: modeValue, toggle: modeToggle } = useButton(
+        s => s.oscillators[OSC].mode,
+        (s, v) => { s.oscillators[OSC].mode = v },
+        3
+    )
+    const { value: syncValue, toggle: syncToggle } = useButton(
+        s => s.oscillators[OSC].sync,
+        (s, v) => { s.oscillators[OSC].sync = v },
+        3
+    )
+    const { value: sawInvValue, toggle: sawInvToggle } = useButton(
+        s => s.oscillators[OSC].sawInv,
+        (s, v) => { s.oscillators[OSC].sawInv = v },
+        2
+    )
+    const { value: preFilterSineValue, toggle: preFilterSineToggle } = useButton(
+        s => s.oscillators[OSC].preFilterSine,
+        (s, v) => { s.oscillators[OSC].preFilterSine = v },
+        2
+    )
+    const { value: subWaveValue, toggle: subWaveToggle } = useButton(
+        s => s.oscillators[OSC].subWave,
+        (s, v) => { s.oscillators[OSC].subWave = v },
+        2
+    )
+    const { displayValue: waveformValue, increment: waveformIncrement } = usePot(
+        s => s.oscillators[OSC].waveform,
+        (s, v) => { s.oscillators[OSC].waveform = v }
+    )
 
     const topRow = y + POT_OFFSET_Y
     const bottomRow = topRow + ROW_HEIGHT
@@ -53,58 +109,58 @@ const DCO2 = ({ x, y, height, width }: ModuleProps) => {
         <RoundPushButton8 x={col1} y={topRow}
                           ledPosition="right" ledCount={3} ledLabels={['DCO', 'WT', 'PCM']}
                           label="Mode" labelPosition="bottom-pot"
-                          ctrlGroup={ctrlGroup}
-                          ctrl={oscControllers.DCO2.MODE}
+                          value={modeValue}
+                          onButtonClick={modeToggle}
         />
 
-        <RotaryPot12 x={col2} y={topRow} label="Keyboard"
-                     ctrlGroup={ctrlGroup}
-                     ctrl={oscControllers.DCO2.KBD}
+        <OscTogglePot x={col2} y={topRow} label="Keyboard"
+                      selector={s => s.oscillators[OSC].kbd}
+                      mutator={(s, v) => { s.oscillators[OSC].kbd = v }}
         />
 
-        <RotaryPot12 x={col3} y={topRow} label="LFO"
-                     ctrlGroup={ctrlGroup}
-                     ctrl={oscControllers.DCO2.LFO}
+        <OscTogglePot x={col3} y={topRow} label="LFO"
+                      selector={s => s.oscillators[OSC].lfo}
+                      mutator={(s, v) => { s.oscillators[OSC].lfo = v }}
         />
 
-        <RotaryPot12 x={col4} y={topRow} ledMode="single" label="Note"
-                     ctrlGroup={ctrlGroup}
-                     ctrl={oscControllers.DCO2.NOTE}
+        <OscPot x={col4} y={topRow} label="Note"
+                selector={s => s.oscillators[OSC].note}
+                mutator={(s, v) => { s.oscillators[OSC].note = v }}
         />
 
-        <RotaryPot12 x={col4} y={bottomRow} ledMode="single" label="Detune"
-                     ctrlGroup={ctrlGroup}
-                     ctrl={oscControllers.DCO2.DETUNE}
+        <OscPot x={col4} y={bottomRow} label="Detune"
+                selector={s => s.oscillators[OSC].detune}
+                mutator={(s, v) => { s.oscillators[OSC].detune = v }}
         />
 
         <RoundPushButton8 x={col1} y={bottomRow}
                           ledPosition="right" ledCount={2} ledLabels={['Hard', 'Metal']}
                           label="Sync" labelPosition="bottom-pot"
                           hasOff
-                          ctrlGroup={ctrlGroup}
-                          ctrl={oscControllers.DCO2.SYNC}
+                          value={syncValue}
+                          onButtonClick={syncToggle}
         />
 
-        <RotaryPot12 x={col3} y={bottomRow} label="Wheel"
-                     ctrlGroup={ctrlGroup}
-                     ctrl={oscControllers.DCO2.WHEEL}
+        <OscTogglePot x={col3} y={bottomRow} label="Wheel"
+                      selector={s => s.oscillators[OSC].wheel}
+                      mutator={(s, v) => { s.oscillators[OSC].wheel = v }}
         />
 
         <RoundLedPushButton8 x={col5} y={topRow} label="Inv saw" labelPosition="bottom"
-                             ctrlGroup={ctrlGroup}
-                             ctrl={oscControllers.DCO2.SAW_INV}
+                             value={sawInvValue}
+                             onButtonClick={sawInvToggle}
         />
 
         <RotaryPot21 x={col6} y={centerRow} ledMode="single" label="Waveform"
-                     ctrlGroup={ctrlGroup}
-                     ctrl={oscControllers.DCO2.WAVEFORM}
+                     value={waveformValue}
+                     onValueIncrement={waveformIncrement}
         />
 
         <WaveformIconsRing x={col6} y={centerRow}/>
 
         <RoundLedPushButton8 x={col7} y={topRow} label="Sine" labelPosition="bottom"
-                             ctrlGroup={ctrlGroup}
-                             ctrl={oscControllers.DCO2.PRE_FILTER_SINE}
+                             value={preFilterSineValue}
+                             onButtonClick={preFilterSineToggle}
         />
 
         <RoundPushButton8 x={col9} y={bottomRow + DUAL_LED_BUTTON_W_LABEL_OFFSET_Y}
@@ -113,23 +169,23 @@ const DCO2 = ({ x, y, height, width }: ModuleProps) => {
             <SawRight x={0} y={0} width={3} height={2}/>,
         ]}
                           label="Sub wave" labelPosition="bottom"
-                          ctrlGroup={ctrlGroup}
-                          ctrl={oscControllers.DCO2.SUB_WAVE}
+                          value={subWaveValue}
+                          onButtonClick={subWaveToggle}
         />
 
-        <RotaryPot12 x={col8} y={topRow} ledMode="multi" label="Sub -1"
-                     ctrlGroup={ctrlGroup}
-                     ctrl={oscControllers.DCO2.SUB1}
+        <OscPot x={col8} y={topRow} ledMode="multi" label="Sub -1"
+                selector={s => s.oscillators[OSC].sub1}
+                mutator={(s, v) => { s.oscillators[OSC].sub1 = v }}
         />
 
-        <RotaryPot12 x={col8} y={bottomRow} ledMode="single" label="Pulse width"
-                     ctrlGroup={ctrlGroup}
-                     ctrl={oscControllers.DCO2.PW}
+        <OscPot x={col8} y={bottomRow} label="Pulse width"
+                selector={s => s.oscillators[OSC].pw}
+                mutator={(s, v) => { s.oscillators[OSC].pw = v }}
         />
 
-        <RotaryPot12 x={col9} y={topRow} ledMode="multi" label="Sub -2"
-                     ctrlGroup={ctrlGroup}
-                     ctrl={oscControllers.DCO2.SUB2}
+        <OscPot x={col9} y={topRow} ledMode="multi" label="Sub -2"
+                selector={s => s.oscillators[OSC].sub2}
+                mutator={(s, v) => { s.oscillators[OSC].sub2 = v }}
         />
 
     </>

--- a/src/components/modules/left2/VCO.tsx
+++ b/src/components/modules/left2/VCO.tsx
@@ -1,27 +1,54 @@
-import React from 'react'
+import React, { useCallback } from 'react'
 import RotaryPot21 from '../../pots/RotaryPot21'
 import RotaryPot12 from '../../pots/RotaryPot12'
 import RoundPushButton8 from '../../buttons/RoundPushButton8'
 import RoundLedPushButton8 from '../../buttons/RoundLedPushButton8'
-import { ControllerGroupIds } from '../../../synthcore/types'
-import oscControllers from '../../../synthcore/modules/osc/oscControllers'
 import SubHeader from "../../misc/SubHeader";
 import {
-    DUAL_LED_BUTTON_W_LABEL_OFFSET_Y, PADDING_LEFT, POT_DISTANCE_L,
-    POT_DISTANCE_M, POT_DISTANCE_S,
+    DUAL_LED_BUTTON_W_LABEL_OFFSET_Y,
+    POT_DISTANCE_L,
+    POT_DISTANCE_M,
+    POT_DISTANCE_S,
     POT_OFFSET_Y,
     ROW_HEIGHT,
-    ROW_SPACING
 } from "../../../constants";
-import { SHOW_CUT } from "../../../config";
 import { VerticalDividerLine } from "../../misc/VerticalDividerLine";
 import { ModuleBorder } from "../../misc/ModuleBorder";
 import { ModuleProps } from "../types";
 import "../Modules.scss"
 import { WaveformIconsRing } from "./WaveformIconsRing";
 import { PwIconsRing } from "./PwIconsRing";
+import { usePot, useButton } from '../../../store/hooks'
+import { VoiceGroupPatch, voiceGroupStores } from '../../../store/patchStore'
+import { useUiStore } from '../../../store/uiStore'
 
-const ctrlGroup = ControllerGroupIds.OSC
+const OSC = 2
+
+const OscPot = ({ x, y, label, ledMode = 'single' as const, selector, mutator }: {
+    x: number, y: number, label: string, ledMode?: 'single' | 'multi',
+    selector: (s: VoiceGroupPatch) => number,
+    mutator: (s: VoiceGroupPatch, v: number) => void,
+}) => {
+    const { displayValue, increment } = usePot(selector, mutator)
+    return <RotaryPot12 x={x} y={y} ledMode={ledMode} label={label}
+                        value={displayValue} onValueIncrement={increment} />
+}
+
+const OscTogglePot = ({ x, y, label, selector, mutator }: {
+    x: number, y: number, label: string,
+    selector: (s: VoiceGroupPatch) => number,
+    mutator: (s: VoiceGroupPatch, v: number) => void,
+}) => {
+    const voiceGroupIndex = useUiStore(s => s.currentVoiceGroupIndex)
+    const { value } = useButton(selector, mutator, 2)
+    const onIncrement = useCallback((delta: number) => {
+        voiceGroupStores[voiceGroupIndex].getState().set(state => {
+            mutator(state, delta > 0 ? 1 : 0)
+        })
+    }, [voiceGroupIndex, mutator])
+    return <RotaryPot12 x={x} y={y} label={label}
+                        value={value} onValueIncrement={onIncrement} />
+}
 
 const VCO = ({ x, y, height, width }: ModuleProps) => {
 
@@ -39,6 +66,36 @@ const VCO = ({ x, y, height, width }: ModuleProps) => {
     const col8 = col7 + POT_DISTANCE_S
     const col9 = col8 + POT_DISTANCE_M
 
+    const { value: syncSrcValue, toggle: syncSrcToggle } = useButton(
+        s => s.oscillators[OSC].syncSrc,
+        (s, v) => { s.oscillators[OSC].syncSrc = v },
+        2
+    )
+    const { value: syncValue, toggle: syncToggle } = useButton(
+        s => s.oscillators[OSC].sync,
+        (s, v) => { s.oscillators[OSC].sync = v },
+        3
+    )
+    const { value: extCvValue, toggle: extCvToggle } = useButton(
+        s => s.oscillators[OSC].extCv,
+        (s, v) => { s.oscillators[OSC].extCv = v },
+        2
+    )
+    const { displayValue: waveformValue, increment: waveformIncrement } = usePot(
+        s => s.oscillators[OSC].waveform,
+        (s, v) => { s.oscillators[OSC].waveform = v }
+    )
+    const { value: fmSrcValue, toggle: fmSrcToggle } = useButton(
+        s => s.oscillators[OSC].fmSrc,
+        (s, v) => { s.oscillators[OSC].fmSrc = v },
+        2
+    )
+    const { value: fmModeValue, toggle: fmModeToggle } = useButton(
+        s => s.oscillators[OSC].fmMode,
+        (s, v) => { s.oscillators[OSC].fmMode = v },
+        3
+    )
+
     return <>
         {/*!SHOW_CUT && <rect x={x-52.5} y={y} width="105" height={130 - ROW_SPACING} className="module-background"/>*/}
         <ModuleBorder x={x} y={y} height={height} width={width} className="audio-elements-border"/>
@@ -49,78 +106,78 @@ const VCO = ({ x, y, height, width }: ModuleProps) => {
         <RoundPushButton8 x={col1} y={topRow}
                           ledPosition="right" ledCount={2} ledLabels={['1', '2']}
                           label="Sync src" labelPosition="bottom-pot"
-                          ctrlGroup={ctrlGroup}
-                          ctrl={oscControllers.VCO.SYNC_SRC}
+                          value={syncSrcValue}
+                          onButtonClick={syncSrcToggle}
         />
 
-        <RotaryPot12 x={col2} y={topRow} label="Keyboard"
-                     ctrlGroup={ctrlGroup}
-                     ctrl={oscControllers.VCO.KBD}
+        <OscTogglePot x={col2} y={topRow} label="Keyboard"
+                      selector={s => s.oscillators[OSC].kbd}
+                      mutator={(s, v) => { s.oscillators[OSC].kbd = v }}
         />
 
-        <RotaryPot12 x={col3} y={topRow} label="LFO"
-                     ctrlGroup={ctrlGroup}
-                     ctrl={oscControllers.VCO.LFO}
+        <OscTogglePot x={col3} y={topRow} label="LFO"
+                      selector={s => s.oscillators[OSC].lfo}
+                      mutator={(s, v) => { s.oscillators[OSC].lfo = v }}
         />
 
-        <RotaryPot12 x={col4} y={topRow} ledMode="single" label="Note"
-                     ctrlGroup={ctrlGroup}
-                     ctrl={oscControllers.VCO.NOTE}
+        <OscPot x={col4} y={topRow} label="Note"
+                selector={s => s.oscillators[OSC].note}
+                mutator={(s, v) => { s.oscillators[OSC].note = v }}
         />
 
-        <RotaryPot12 x={col4} y={bottomRow} ledMode="single" label="Detune"
-                     ctrlGroup={ctrlGroup}
-                     ctrl={oscControllers.VCO.DETUNE}
+        <OscPot x={col4} y={bottomRow} label="Detune"
+                selector={s => s.oscillators[OSC].detune}
+                mutator={(s, v) => { s.oscillators[OSC].detune = v }}
         />
 
         <RoundPushButton8 x={col1} y={bottomRow}
                           ledPosition="right" ledCount={2} ledLabels={['Hard', 'CEM']}
                           label="Sync" labelPosition="bottom-pot"
                           hasOff
-                          ctrlGroup={ctrlGroup}
-                          ctrl={oscControllers.VCO.SYNC}
+                          value={syncValue}
+                          onButtonClick={syncToggle}
         />
 
         <RoundLedPushButton8 x={col2} y={bottomRow} label="Ext CV" labelPosition="bottom-pot"
-                             ctrlGroup={ctrlGroup}
-                             ctrl={oscControllers.VCO.EXT_CV}
+                             value={extCvValue}
+                             onButtonClick={extCvToggle}
         />
 
-        <RotaryPot12 x={col3} y={bottomRow} label="Wheel"
-                     ctrlGroup={ctrlGroup}
-                     ctrl={oscControllers.VCO.WHEEL}
+        <OscTogglePot x={col3} y={bottomRow} label="Wheel"
+                      selector={s => s.oscillators[OSC].wheel}
+                      mutator={(s, v) => { s.oscillators[OSC].wheel = v }}
         />
 
         <RotaryPot21 x={col6} y={centerRow} ledMode="single" label="Waveform"
-                     ctrlGroup={ctrlGroup}
-                     ctrl={oscControllers.VCO.WAVEFORM}
+                     value={waveformValue}
+                     onValueIncrement={waveformIncrement}
         />
 
         <WaveformIconsRing x={col6} y={centerRow} />
 
-        <RotaryPot12 x={col8} y={topRow} ledMode="multi" label="FM"
-                     ctrlGroup={ctrlGroup}
-                     ctrl={oscControllers.VCO.FM_AMT}
+        <OscPot x={col8} y={topRow} ledMode="multi" label="FM"
+                selector={s => s.oscillators[OSC].fmAmt}
+                mutator={(s, v) => { s.oscillators[OSC].fmAmt = v }}
         />
 
         <RoundPushButton8 x={col9} y={topRow + DUAL_LED_BUTTON_W_LABEL_OFFSET_Y}
                           ledPosition="top-horizontal" ledCount={2} ledLabels={['2', 'Ext']}
                           label="FM src" labelPosition="bottom"
-                          ctrlGroup={ctrlGroup}
-                          ctrl={oscControllers.VCO.FM_SRC}
+                          value={fmSrcValue}
+                          onButtonClick={fmSrcToggle}
         />
 
-        <RotaryPot12 x={col8} y={bottomRow} ledMode="single" label="Pulse width"
-                     ctrlGroup={ctrlGroup}
-                     ctrl={oscControllers.VCO.PW}
+        <OscPot x={col8} y={bottomRow} label="Pulse width"
+                selector={s => s.oscillators[OSC].pw}
+                mutator={(s, v) => { s.oscillators[OSC].pw = v }}
         />
 
         <RoundPushButton8 x={col9} y={bottomRow + +DUAL_LED_BUTTON_W_LABEL_OFFSET_Y}
                           ledPosition="top-horizontal" ledCount={2} ledLabels={['Lin', 'Log']}
                           label="FM mode" labelPosition="bottom"
                           hasOff
-                          ctrlGroup={ctrlGroup}
-                          ctrl={oscControllers.VCO.FM_MODE}
+                          value={fmModeValue}
+                          onButtonClick={fmModeToggle}
         />
     </>
 }

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -13,6 +13,7 @@ import { startSimpleButtonMidiReceive } from './store/midi/simpleButtonMidiRecei
 import { startFxKbdMidiSend, startFxKbdMidiReceive } from './store/midi/fxKbdMidi'
 import { startSrcMixMidiSend, startSrcMixMidiReceive } from './store/midi/srcMixMidi'
 import { startOutPostMixMidiSend, startOutPostMixMidiReceive } from './store/midi/outMidi'
+import { startOscMidiSend, startOscMidiReceive } from './store/midi/oscMidi'
 
 midiApi.initReceive()
 startEnvelopeMidiSend()
@@ -25,6 +26,8 @@ startSrcMixMidiSend()
 startSrcMixMidiReceive()
 startOutPostMixMidiSend()
 startOutPostMixMidiReceive()
+startOscMidiSend()
+startOscMidiReceive()
 
 const root = ReactDOM.createRoot(
   document.getElementById('root') as HTMLElement

--- a/src/store/midi/oscMidi.ts
+++ b/src/store/midi/oscMidi.ts
@@ -1,0 +1,159 @@
+/**
+ * MIDI send/receive for oscillators: subscribes to Zustand store changes
+ * and sends changed parameters over MIDI, and subscribes to midibus to
+ * write incoming MIDI values to the Zustand stores.
+ *
+ * Handles all 3 oscillators: DCO1 (index 0), DCO2 (index 1), VCO (index 2).
+ */
+
+import { voiceGroupStores, OscillatorState } from '../patchStore'
+import { cc, button } from '../../midi/midibus'
+import { ControllerConfigCC, ControllerConfigButton } from '../../midi/types'
+import oscControllers from '../../synthcore/modules/osc/oscControllers'
+import { isMidiReceiving, withMidiReceive } from './midiGuard'
+
+type OscField = keyof OscillatorState
+
+interface CCMapping {
+    oscIndex: number
+    field: OscField
+    ctrl: ControllerConfigCC
+}
+
+interface ButtonMapping {
+    oscIndex: number
+    field: OscField
+    ctrl: ControllerConfigButton
+}
+
+const ccMappings: CCMapping[] = [
+    // DCO1
+    { oscIndex: 0, field: 'note', ctrl: oscControllers.DCO1.NOTE },
+    { oscIndex: 0, field: 'detune', ctrl: oscControllers.DCO1.DETUNE },
+    { oscIndex: 0, field: 'waveform', ctrl: oscControllers.DCO1.WAVEFORM },
+    { oscIndex: 0, field: 'sub1', ctrl: oscControllers.DCO1.SUB1 },
+    { oscIndex: 0, field: 'sub2', ctrl: oscControllers.DCO1.SUB2 },
+    { oscIndex: 0, field: 'pw', ctrl: oscControllers.DCO1.PW },
+    // DCO2
+    { oscIndex: 1, field: 'note', ctrl: oscControllers.DCO2.NOTE },
+    { oscIndex: 1, field: 'detune', ctrl: oscControllers.DCO2.DETUNE },
+    { oscIndex: 1, field: 'waveform', ctrl: oscControllers.DCO2.WAVEFORM },
+    { oscIndex: 1, field: 'sub1', ctrl: oscControllers.DCO2.SUB1 },
+    { oscIndex: 1, field: 'sub2', ctrl: oscControllers.DCO2.SUB2 },
+    { oscIndex: 1, field: 'pw', ctrl: oscControllers.DCO2.PW },
+    // VCO
+    { oscIndex: 2, field: 'note', ctrl: oscControllers.VCO.NOTE },
+    { oscIndex: 2, field: 'detune', ctrl: oscControllers.VCO.DETUNE },
+    { oscIndex: 2, field: 'waveform', ctrl: oscControllers.VCO.WAVEFORM },
+    { oscIndex: 2, field: 'fmAmt', ctrl: oscControllers.VCO.FM_AMT },
+    { oscIndex: 2, field: 'pw', ctrl: oscControllers.VCO.PW },
+    { oscIndex: 2, field: 'linFm', ctrl: oscControllers.VCO.LIN_FM },
+]
+
+const buttonMappings: ButtonMapping[] = [
+    // DCO1
+    { oscIndex: 0, field: 'range', ctrl: oscControllers.DCO1.RANGE },
+    { oscIndex: 0, field: 'sync', ctrl: oscControllers.DCO1.SYNC },
+    { oscIndex: 0, field: 'mode', ctrl: oscControllers.DCO1.MODE },
+    { oscIndex: 0, field: 'subWave', ctrl: oscControllers.DCO1.SUB_WAVE },
+    { oscIndex: 0, field: 'wheel', ctrl: oscControllers.DCO1.WHEEL },
+    { oscIndex: 0, field: 'lfo', ctrl: oscControllers.DCO1.LFO },
+    { oscIndex: 0, field: 'kbd', ctrl: oscControllers.DCO1.KBD },
+    { oscIndex: 0, field: 'sawInv', ctrl: oscControllers.DCO1.SAW_INV },
+    { oscIndex: 0, field: 'preFilterSine', ctrl: oscControllers.DCO1.PRE_FILTER_SINE },
+    // DCO2
+    { oscIndex: 1, field: 'range', ctrl: oscControllers.DCO2.RANGE },
+    { oscIndex: 1, field: 'sync', ctrl: oscControllers.DCO2.SYNC },
+    { oscIndex: 1, field: 'mode', ctrl: oscControllers.DCO2.MODE },
+    { oscIndex: 1, field: 'subWave', ctrl: oscControllers.DCO2.SUB_WAVE },
+    { oscIndex: 1, field: 'wheel', ctrl: oscControllers.DCO2.WHEEL },
+    { oscIndex: 1, field: 'lfo', ctrl: oscControllers.DCO2.LFO },
+    { oscIndex: 1, field: 'kbd', ctrl: oscControllers.DCO2.KBD },
+    { oscIndex: 1, field: 'sawInv', ctrl: oscControllers.DCO2.SAW_INV },
+    { oscIndex: 1, field: 'preFilterSine', ctrl: oscControllers.DCO2.PRE_FILTER_SINE },
+    // VCO
+    { oscIndex: 2, field: 'sync', ctrl: oscControllers.VCO.SYNC },
+    { oscIndex: 2, field: 'syncSrc', ctrl: oscControllers.VCO.SYNC_SRC },
+    { oscIndex: 2, field: 'fmSrc', ctrl: oscControllers.VCO.FM_SRC },
+    { oscIndex: 2, field: 'fmMode', ctrl: oscControllers.VCO.FM_MODE },
+    { oscIndex: 2, field: 'extCv', ctrl: oscControllers.VCO.EXT_CV },
+    { oscIndex: 2, field: 'wheel', ctrl: oscControllers.VCO.WHEEL },
+    { oscIndex: 2, field: 'lfo', ctrl: oscControllers.VCO.LFO },
+    { oscIndex: 2, field: 'kbd', ctrl: oscControllers.VCO.KBD },
+]
+
+let sendUnsubscribers: (() => void)[] = []
+let receiveUnsubscribers: (() => void)[] = []
+
+export function startOscMidiSend() {
+    stopOscMidiSend()
+
+    voiceGroupStores.forEach((store, voiceGroupIndex) => {
+        let previousOscillators = store.getState().oscillators
+
+        const unsub = store.subscribe((state) => {
+            if (isMidiReceiving()) {
+                previousOscillators = state.oscillators
+                return
+            }
+            if (state.oscillators !== previousOscillators) {
+                const prev = previousOscillators
+                previousOscillators = state.oscillators
+
+                for (const { oscIndex, field, ctrl } of ccMappings) {
+                    if (state.oscillators[oscIndex][field] !== prev[oscIndex][field]) {
+                        cc.send(voiceGroupIndex, ctrl, Math.floor(127 * state.oscillators[oscIndex][field]))
+                    }
+                }
+
+                for (const { oscIndex, field, ctrl } of buttonMappings) {
+                    if (state.oscillators[oscIndex][field] !== prev[oscIndex][field]) {
+                        button.send(voiceGroupIndex, ctrl, ctrl.values[state.oscillators[oscIndex][field]])
+                    }
+                }
+            }
+        })
+
+        sendUnsubscribers.push(unsub)
+    })
+}
+
+export function stopOscMidiSend() {
+    sendUnsubscribers.forEach(unsub => unsub())
+    sendUnsubscribers = []
+}
+
+export function startOscMidiReceive() {
+    stopOscMidiReceive()
+
+    for (const { oscIndex, field, ctrl } of ccMappings) {
+        const id = cc.subscribe((voiceGroupIndex: number, midiValue: number) => {
+            const value = midiValue / 127
+            withMidiReceive(() => {
+                voiceGroupStores[voiceGroupIndex].getState().set(state => {
+                    state.oscillators[oscIndex][field] = value
+                })
+            })
+        }, ctrl)
+        receiveUnsubscribers.push(() => cc.unsubscribe(ctrl, id))
+    }
+
+    for (const { oscIndex, field, ctrl } of buttonMappings) {
+        const id = button.subscribe((voiceGroupIndex: number, midiValue: number) => {
+            const value = ctrl.values.indexOf(midiValue)
+            if (value < 0) return
+
+            withMidiReceive(() => {
+                voiceGroupStores[voiceGroupIndex].getState().set(state => {
+                    state.oscillators[oscIndex][field] = value
+                })
+            })
+        }, ctrl)
+        receiveUnsubscribers.push(() => button.unsubscribe(ctrl, id))
+    }
+}
+
+export function stopOscMidiReceive() {
+    receiveUnsubscribers.forEach(unsub => unsub())
+    receiveUnsubscribers = []
+}

--- a/src/store/patchStore.ts
+++ b/src/store/patchStore.ts
@@ -76,6 +76,12 @@ export interface OscillatorState {
     kbd: number
     sawInv: number
     preFilterSine: number
+    fmAmt: number
+    linFm: number
+    syncSrc: number
+    fmSrc: number
+    fmMode: number
+    extCv: number
 }
 
 export interface FilterState {
@@ -303,6 +309,12 @@ const defaultOscillator = (): OscillatorState => ({
     kbd: 0,
     sawInv: 0,
     preFilterSine: 0,
+    fmAmt: 0,
+    linFm: 0,
+    syncSrc: 0,
+    fmSrc: 0,
+    fmMode: 0,
+    extCv: 0,
 })
 
 const defaultFilter = (): FilterState => ({


### PR DESCRIPTION
## Summary
- Add VCO-specific fields to `OscillatorState`: `fmAmt`, `linFm`, `syncSrc`, `fmSrc`, `fmMode`, `extCv`
- Rewrite DCO1, DCO2, VCO components to use `usePot`/`useButton` Zustand hooks
- Button-type params displayed as pots (Wheel, LFO, KBD) use custom `OscTogglePot` wrapper: clockwise → on, counterclockwise → off
- Add MIDI send/receive for all CC pots and button params across 3 oscillators (NRPN pitch skipped for now)
- 13 new tests covering oscillator CC and button MIDI send/receive

## Notes
- All 3 oscillators share `OscillatorState` — VCO-specific fields are unused (0) for DCO1/DCO2
- PITCH param uses NRPN encoding — deferred to a separate PR

## Test plan
- [x] All 166 tests pass, no regressions
- [ ] Verify DCO1/DCO2 pots and buttons respond in UI
- [ ] Verify VCO pots and buttons (FM, sync src, ext CV) respond in UI
- [ ] Verify Wheel/LFO/KBD toggle-pots snap to on/off
- [ ] Verify MIDI send/receive for all oscillator parameters

🤖 Generated with [Claude Code](https://claude.com/claude-code)