### PR TITLE
Wire LPF and SVF filters to Zustand with MIDI

### DIFF
--- a/src/__tests__/store/filterMidi.test.ts
+++ b/src/__tests__/store/filterMidi.test.ts
@@ -1,0 +1,131 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+
+vi.mock('../../synthcore/synthcoreMiddleware', () => ({
+    synthcoreMiddleware: () => (next: any) => (action: any) => next(action),
+}))
+
+import { cc, button } from '../../midi/midibus'
+import { voiceGroupStores, createPatchStore } from '../../store/patchStore'
+import filtersControllers from '../../synthcore/modules/filters/filtersControllers'
+import { buttonMidiValues } from '../../midi/buttonMidiValues'
+import {
+    startFilterMidiSend,
+    stopFilterMidiSend,
+    startFilterMidiReceive,
+    stopFilterMidiReceive,
+} from '../../store/midi/filterMidi'
+
+const VG = 0
+
+function getState() {
+    return voiceGroupStores[VG].getState()
+}
+
+function resetStore() {
+    const fresh = createPatchStore()
+    voiceGroupStores[VG].getState().loadPatch(fresh.getState().getPatch())
+}
+
+describe('filter MIDI receive', () => {
+    beforeEach(() => {
+        resetStore()
+        startFilterMidiReceive()
+    })
+
+    afterEach(() => {
+        stopFilterMidiReceive()
+    })
+
+    it('sets LPF cutoff from CC', () => {
+        cc.publish(VG, filtersControllers.LPF.CUTOFF.cc, 100)
+        expect(getState().filters[0].cutoff).toBeCloseTo(100 / 127, 2)
+    })
+
+    it('sets SVF resonance from CC', () => {
+        cc.publish(VG, filtersControllers.SVF.RESONANCE.cc, 64)
+        expect(getState().filters[1].resonance).toBeCloseTo(64 / 127, 2)
+    })
+
+    it('sets LPF fm mode from button MIDI', () => {
+        button.publish(VG, buttonMidiValues.LPF_FM_MODE_LIN)
+        expect(getState().filters[0].fmMode).toBe(1)
+    })
+
+    it('sets SVF slope from button MIDI', () => {
+        button.publish(VG, buttonMidiValues.SVF_SLOPE_24DB_BP)
+        expect(getState().filters[1].slope).toBe(3)
+    })
+
+    it('sets SVF invert from button MIDI', () => {
+        button.publish(VG, buttonMidiValues.SVF_INVERT_ON)
+        expect(getState().filters[1].invert).toBe(1)
+    })
+
+    it('sets shared routing from button MIDI', () => {
+        button.publish(VG, buttonMidiValues.FILTER_ROUTING_PARALLEL)
+        expect(getState().filters[0].routing).toBe(1)
+    })
+
+    it('sets shared link cutoff from button MIDI', () => {
+        button.publish(VG, buttonMidiValues.FILTER_LINK_CUTOFF_ON)
+        expect(getState().filters[0].linkCutoff).toBe(1)
+    })
+})
+
+describe('filter MIDI send', () => {
+    let sentCC: { ccNum: number, value: number }[] = []
+    let sentButtons: { ctrl: any, value: number }[] = []
+    const origCCSend = cc.send
+    const origButtonSend = button.send
+
+    beforeEach(() => {
+        resetStore()
+        sentCC = []
+        sentButtons = []
+        cc.send = vi.fn((vg, ctrl, value) => {
+            sentCC.push({ ccNum: ctrl.cc, value })
+        }) as any
+        button.send = vi.fn((vg, ctrl, value) => {
+            sentButtons.push({ ctrl, value })
+        }) as any
+        startFilterMidiSend()
+    })
+
+    afterEach(() => {
+        stopFilterMidiSend()
+        cc.send = origCCSend
+        button.send = origButtonSend
+    })
+
+    it('sends LPF cutoff as CC', () => {
+        getState().set(s => { s.filters[0].cutoff = 0.6 })
+        const sent = sentCC.find(s => s.ccNum === filtersControllers.LPF.CUTOFF.cc)
+        expect(sent).toBeDefined()
+        expect(sent!.value).toBe(Math.floor(127 * 0.6))
+    })
+
+    it('sends SVF input as CC', () => {
+        getState().set(s => { s.filters[1].input = 0.8 })
+        const sent = sentCC.find(s => s.ccNum === filtersControllers.SVF.INPUT.cc)
+        expect(sent).toBeDefined()
+        expect(sent!.value).toBe(Math.floor(127 * 0.8))
+    })
+
+    it('sends LPF filter type as button MIDI', () => {
+        getState().set(s => { s.filters[0].filterType = 1 })
+        const sent = sentButtons.find(s => s.value === buttonMidiValues.LPF_FILTER_TYPE_LADDER)
+        expect(sent).toBeDefined()
+    })
+
+    it('sends SVF invert as button MIDI', () => {
+        getState().set(s => { s.filters[1].invert = 1 })
+        const sent = sentButtons.find(s => s.value === buttonMidiValues.SVF_INVERT_ON)
+        expect(sent).toBeDefined()
+    })
+
+    it('does not send when value unchanged', () => {
+        const defaultCutoff = getState().filters[0].cutoff
+        getState().set(s => { s.filters[0].cutoff = defaultCutoff })
+        expect(sentCC.find(s => s.ccNum === filtersControllers.LPF.CUTOFF.cc)).toBeUndefined()
+    })
+})

--- a/src/components/buttons/RoundButtonBase.tsx
+++ b/src/components/buttons/RoundButtonBase.tsx
@@ -80,6 +80,7 @@ export interface Props {
 
     onButtonClick?: () => void;
     onButtonRelease?: () => void;
+    onIncrement?: (steps: number) => void;
 }
 
 type LabelPos = {
@@ -305,6 +306,7 @@ export const RoundButtonBase = (props: Props & Config) => {
         ledCycleBinary,
         onButtonClick,
         onButtonRelease,
+        onIncrement: onIncrementProp,
     } = props
 
     const storeValue = useAppSelector(ctrl ? selectUiController(ctrl, ctrlIndex || 0) : () => 0)
@@ -315,7 +317,9 @@ export const RoundButtonBase = (props: Props & Config) => {
     const ledOnIndex = hasOffValue ? currentValue - 1 : currentValue
 
     const onIncrement = useCallback((steps: number) => {
-        if (onButtonClick) {
+        if (onIncrementProp) {
+            onIncrementProp(steps)
+        } else if (onButtonClick) {
             for (let i = 0; i < Math.abs(steps); i++) {
                 onButtonClick()
             }
@@ -328,7 +332,7 @@ export const RoundButtonBase = (props: Props & Config) => {
                 }
             }
         }
-    }, [ctrlGroup, ctrl, loop, valueIndex, onButtonClick])
+    }, [ctrlGroup, ctrl, loop, valueIndex, onButtonClick, onIncrementProp])
 
     const handleOnClick = useCallback(() => {
         if (onButtonClick) {

--- a/src/components/modules/right/LowPassFilter.tsx
+++ b/src/components/modules/right/LowPassFilter.tsx
@@ -2,18 +2,36 @@ import React from 'react'
 import RotaryPot21 from '../../pots/RotaryPot21'
 import RotaryPot12 from '../../pots/RotaryPot12'
 import RoundPushButton8 from '../../buttons/RoundPushButton8'
+import RoundLedPushButton8 from '../../buttons/RoundLedPushButton8'
 import { ControllerGroupIds } from '../../../synthcore/types'
 import filtersControllers from '../../../synthcore/modules/filters/filtersControllers'
 import { POT_DISTANCE_L, POT_DISTANCE_M, POT_OFFSET_Y, ROW_HEIGHT } from "../../../constants";
-import RoundLedPushButton8 from "../../buttons/RoundLedPushButton8";
 import { ModuleBorder } from "../../misc/ModuleBorder";
 import SubHeader from "../../misc/SubHeader";
 import { ModuleProps } from "../types";
+import { HorizontalDividerLine } from "../../misc/HorizontalDividerLine";
+import { usePot, useButton } from '../../../store/hooks'
+import { VoiceGroupPatch } from '../../../store/patchStore'
 import './LowPassFilter.scss'
 import "../Modules.scss"
-import { HorizontalDividerLine } from "../../misc/HorizontalDividerLine";
 
 const ctrlGroup = ControllerGroupIds.FILTERS
+const FILTER = 0
+
+const FilterPot = ({ x, y, label, ledMode = 'multi' as const, selector, mutator, Large }: {
+    x: number, y: number, label: string, ledMode?: 'single' | 'multi',
+    selector: (s: VoiceGroupPatch) => number,
+    mutator: (s: VoiceGroupPatch, v: number) => void,
+    Large?: boolean,
+}) => {
+    const { displayValue, increment } = usePot(selector, mutator)
+    if (Large) {
+        return <RotaryPot21 x={x} y={y} ledMode={ledMode} label={label}
+                            value={displayValue} onValueIncrement={increment} />
+    }
+    return <RotaryPot12 x={x} y={y} ledMode={ledMode} label={label}
+                        value={displayValue} onValueIncrement={increment} />
+}
 
 const LowPassFilter = ({ x, y, height, width }: ModuleProps) => {
     const topRow = y + POT_OFFSET_Y
@@ -28,61 +46,92 @@ const LowPassFilter = ({ x, y, height, width }: ModuleProps) => {
     const col4 = col2 + POT_DISTANCE_M
     const col5 = col4 + POT_DISTANCE_M
 
+    const { value: fmModeValue, toggle: fmModeToggle } = useButton(
+        s => s.filters[FILTER].fmMode,
+        (s, v) => { s.filters[FILTER].fmMode = v },
+        3
+    )
+    const { value: filterTypeValue, toggle: filterTypeToggle } = useButton(
+        s => s.filters[FILTER].filterType,
+        (s, v) => { s.filters[FILTER].filterType = v },
+        2
+    )
+    const { value: slopeValue, toggle: slopeToggle } = useButton(
+        s => s.filters[FILTER].slope,
+        (s, v) => { s.filters[FILTER].slope = v },
+        2
+    )
+    const { value: fmSrcValue, toggle: fmSrcToggle } = useButton(
+        s => s.filters[FILTER].fmSrc,
+        (s, v) => { s.filters[FILTER].fmSrc = v },
+        2
+    )
+    const { value: routingValue, toggle: routingToggle } = useButton(
+        s => s.filters[FILTER].routing,
+        (s, v) => { s.filters[FILTER].routing = v },
+        2
+    )
+    const { value: linkCutoffValue, toggle: linkCutoffToggle } = useButton(
+        s => s.filters[FILTER].linkCutoff,
+        (s, v) => { s.filters[FILTER].linkCutoff = v },
+        2
+    )
+
     return <>
         <ModuleBorder x={x} y={y} height={height} width={width} className="audio-elements-border"/>
         <SubHeader label="LPF" x={x} y={y} width={width} labelPosition="center" className="lpf-header-border" labelWidth={15}/>
 
-        <RotaryPot21 x={col3} y={centerRow} ledMode="single" label="Cutoff"
-                     ctrlGroup={ctrlGroup}
-                     ctrl={filtersControllers.LPF.CUTOFF}
+        <FilterPot x={col3} y={centerRow} ledMode="single" label="Cutoff" Large
+                   selector={s => s.filters[FILTER].cutoff}
+                   mutator={(s, v) => { s.filters[FILTER].cutoff = v }}
         />
 
-        <RotaryPot12 x={col1} y={topRow} ledMode="multi" label="In dry/wet"
-                     ctrlGroup={ctrlGroup}
-                     ctrl={filtersControllers.LPF.INPUT}
+        <FilterPot x={col1} y={topRow} label="In dry/wet"
+                   selector={s => s.filters[FILTER].input}
+                   mutator={(s, v) => { s.filters[FILTER].input = v }}
         />
 
-        <RotaryPot12 x={col3} y={topRow} ledMode="multi" label="Resonance"
-                     ctrlGroup={ctrlGroup}
-                     ctrl={filtersControllers.LPF.RESONANCE}
+        <FilterPot x={col3} y={topRow} label="Resonance"
+                   selector={s => s.filters[FILTER].resonance}
+                   mutator={(s, v) => { s.filters[FILTER].resonance = v }}
         />
 
-        <RotaryPot12 x={col5} y={topRow} ledMode="multi" label="FM"
-                     ctrlGroup={ctrlGroup}
-                     ctrl={filtersControllers.LPF.FM_AMT}
+        <FilterPot x={col5} y={topRow} label="FM"
+                   selector={s => s.filters[FILTER].fmAmt}
+                   mutator={(s, v) => { s.filters[FILTER].fmAmt = v }}
         />
 
         <RoundPushButton8 x={col1} y={fmRow} ledPosition="top" ledCount={2} ledLabels={['Lin', 'Log']}
                           label="FM mode" labelPosition="bottom"
                           hasOff
-                          ctrlGroup={ctrlGroup}
-                          ctrl={filtersControllers.LPF.FM_MODE}
+                          value={fmModeValue}
+                          onButtonClick={fmModeToggle}
         />
 
         <RoundPushButton8 x={col1} y={bottomRow1} ledPosition="top" ledCount={2} ledLabels={['OTA', 'Ladder']}
                           label="Filter" labelPosition="bottom"
-                          ctrlGroup={ctrlGroup}
-                          ctrl={filtersControllers.LPF.FILTER_TYPE}
+                          value={filterTypeValue}
+                          onButtonClick={filterTypeToggle}
         />
 
         <RoundPushButton8 x={col2} y={bottomRow1} ledPosition="top" ledCount={2} ledLabels={['12dB', '24dB']}
                           label="Slope" labelPosition="bottom"
-                          ctrlGroup={ctrlGroup}
-                          ctrl={filtersControllers.LPF.SLOPE}
+                          value={slopeValue}
+                          onButtonClick={slopeToggle}
         />
 
         <RoundPushButton8 x={col4} y={bottomRow1}
                           ledPosition="top"
                           ledCount={2}
                           ledLabels={['Series', 'Parallel']} label="Routing" labelPosition="bottom"
-                          ctrlGroup={ctrlGroup}
-                          ctrl={filtersControllers.FILTERS.ROUTING}
+                          value={routingValue}
+                          onButtonClick={routingToggle}
         />
 
         <RoundLedPushButton8 x={col5} y={bottomRow1}
                              label="Link cutoff" labelPosition="bottom"
-                             ctrlGroup={ctrlGroup}
-                             ctrl={filtersControllers.FILTERS.LINK_CUTOFF}
+                             value={linkCutoffValue}
+                             onButtonClick={linkCutoffToggle}
         />
 
         {/*
@@ -93,20 +142,20 @@ const LowPassFilter = ({ x, y, height, width }: ModuleProps) => {
 
         <RoundPushButton8 x={col5} y={fmRow} ledPosition="top" ledCount={2} ledLabels={['2', 'Ext']}
                           label="FM src" labelPosition="bottom"
-                          ctrlGroup={ctrlGroup}
-                          ctrl={filtersControllers.LPF.FM_SRC}
+                          value={fmSrcValue}
+                          onButtonClick={fmSrcToggle}
         />
 
         <HorizontalDividerLine x={x} y={bottomRow2 - 12.5} width={width}/>
 
-        <RotaryPot12 x={col1} y={bottomRow2} ledMode="multi" label="Keyboard"
-                     ctrlGroup={ctrlGroup}
-                     ctrl={filtersControllers.LPF.KBD_AMT}
+        <FilterPot x={col1} y={bottomRow2} label="Keyboard"
+                   selector={s => s.filters[FILTER].kbdAmt}
+                   mutator={(s, v) => { s.filters[FILTER].kbdAmt = v }}
         />
 
-        <RotaryPot12 x={col2} y={bottomRow2} ledMode="multi" label="LFO"
-                     ctrlGroup={ctrlGroup}
-                     ctrl={filtersControllers.LPF.LFO_AMT}
+        <FilterPot x={col2} y={bottomRow2} label="LFO"
+                   selector={s => s.filters[FILTER].lfoAmt}
+                   mutator={(s, v) => { s.filters[FILTER].lfoAmt = v }}
         />
 
         <RotaryPot12 x={col4} y={bottomRow2} ledMode="multi" label="Wheel amt"
@@ -114,9 +163,9 @@ const LowPassFilter = ({ x, y, height, width }: ModuleProps) => {
                      ctrl={filtersControllers.LPF.WHEEL_AMT}
         />
 
-        <RotaryPot12 x={col5} y={bottomRow2} ledMode="multi" label="Envelope"
-                     ctrlGroup={ctrlGroup}
-                     ctrl={filtersControllers.LPF.ENV_AMT}
+        <FilterPot x={col5} y={bottomRow2} label="Envelope"
+                   selector={s => s.filters[FILTER].envAmt}
+                   mutator={(s, v) => { s.filters[FILTER].envAmt = v }}
         />
 
     </>

--- a/src/components/modules/right/StateVariableFilter.tsx
+++ b/src/components/modules/right/StateVariableFilter.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useCallback } from 'react'
 import RotaryPot21 from '../../pots/RotaryPot21'
 import RotaryPot12 from '../../pots/RotaryPot12'
 import RoundPushButton8 from '../../buttons/RoundPushButton8'
@@ -12,7 +12,8 @@ import { ModuleBorder } from "../../misc/ModuleBorder";
 import { ModuleProps } from "../types";
 import { HorizontalDividerLine } from "../../misc/HorizontalDividerLine";
 import { usePot, useButton } from '../../../store/hooks'
-import { VoiceGroupPatch } from '../../../store/patchStore'
+import { VoiceGroupPatch, voiceGroupStores } from '../../../store/patchStore'
+import { useUiStore } from '../../../store/uiStore'
 import "./StateVariableFilter.scss"
 import "../Modules.scss"
 
@@ -57,11 +58,20 @@ const StateVariableFilter = ({ x, y, height, width }: ModuleProps) => {
         (s, v) => { s.filters[FILTER].fmSrc = v },
         2
     )
-    const { value: slopeValue, toggle: slopeToggle } = useButton(
+    const voiceGroupIndex = useUiStore(s => s.currentVoiceGroupIndex)
+    const slopeValue = useButton(
         s => s.filters[FILTER].slope,
         (s, v) => { s.filters[FILTER].slope = v },
         10
-    )
+    ).value
+    const slopeIncrement = useCallback((delta: number) => {
+        const store = voiceGroupStores[voiceGroupIndex].getState()
+        const current = store.filters[FILTER].slope
+        const next = current + (delta > 0 ? 1 : -1)
+        if (next >= 0 && next < 10) {
+            store.set(state => { state.filters[FILTER].slope = next })
+        }
+    }, [voiceGroupIndex])
     const { value: invertValue, toggle: invertToggle } = useButton(
         s => s.filters[FILTER].invert,
         (s, v) => { s.filters[FILTER].invert = v },
@@ -138,7 +148,7 @@ const StateVariableFilter = ({ x, y, height, width }: ModuleProps) => {
                              ]}
                              resolution={10}
                              value={slopeValue}
-                             onButtonClick={slopeToggle}
+                             onIncrement={slopeIncrement}
         />
 
         <HorizontalDividerLine x={x} y={bottomRow2 - 12.5} width={width}/>

--- a/src/components/modules/right/StateVariableFilter.tsx
+++ b/src/components/modules/right/StateVariableFilter.tsx
@@ -10,11 +10,29 @@ import SubHeader from "../../misc/SubHeader";
 import { POT_DISTANCE_L, POT_DISTANCE_M, POT_OFFSET_Y, ROW_HEIGHT } from "../../../constants";
 import { ModuleBorder } from "../../misc/ModuleBorder";
 import { ModuleProps } from "../types";
+import { HorizontalDividerLine } from "../../misc/HorizontalDividerLine";
+import { usePot, useButton } from '../../../store/hooks'
+import { VoiceGroupPatch } from '../../../store/patchStore'
 import "./StateVariableFilter.scss"
 import "../Modules.scss"
-import { HorizontalDividerLine } from "../../misc/HorizontalDividerLine";
 
 const ctrlGroup = ControllerGroupIds.FILTERS
+const FILTER = 1
+
+const FilterPot = ({ x, y, label, ledMode = 'multi' as const, selector, mutator, Large }: {
+    x: number, y: number, label: string, ledMode?: 'single' | 'multi',
+    selector: (s: VoiceGroupPatch) => number,
+    mutator: (s: VoiceGroupPatch, v: number) => void,
+    Large?: boolean,
+}) => {
+    const { displayValue, increment } = usePot(selector, mutator)
+    if (Large) {
+        return <RotaryPot21 x={x} y={y} ledMode={ledMode} label={label}
+                            value={displayValue} onValueIncrement={increment} />
+    }
+    return <RotaryPot12 x={x} y={y} ledMode={ledMode} label={label}
+                        value={displayValue} onValueIncrement={increment} />
+}
 
 const StateVariableFilter = ({ x, y, height, width }: ModuleProps) => {
     const topRow = y + POT_OFFSET_Y
@@ -28,6 +46,28 @@ const StateVariableFilter = ({ x, y, height, width }: ModuleProps) => {
     const col3 = col2 + POT_DISTANCE_M / 2
     const col4 = col2 + POT_DISTANCE_M
     const col5 = col4 + POT_DISTANCE_M
+
+    const { value: fmModeValue, toggle: fmModeToggle } = useButton(
+        s => s.filters[FILTER].fmMode,
+        (s, v) => { s.filters[FILTER].fmMode = v },
+        3
+    )
+    const { value: fmSrcValue, toggle: fmSrcToggle } = useButton(
+        s => s.filters[FILTER].fmSrc,
+        (s, v) => { s.filters[FILTER].fmSrc = v },
+        2
+    )
+    const { value: slopeValue, toggle: slopeToggle } = useButton(
+        s => s.filters[FILTER].slope,
+        (s, v) => { s.filters[FILTER].slope = v },
+        10
+    )
+    const { value: invertValue, toggle: invertToggle } = useButton(
+        s => s.filters[FILTER].invert,
+        (s, v) => { s.filters[FILTER].invert = v },
+        2
+    )
+
     // modes:
     /*
     2p LP
@@ -50,38 +90,38 @@ const StateVariableFilter = ({ x, y, height, width }: ModuleProps) => {
                    className="svf-header-border"
         />
 
-        <RotaryPot21 x={col3} y={centerRow} ledMode="single" label="Cutoff"
-                     ctrlGroup={ctrlGroup}
-                     ctrl={filtersControllers.SVF.CUTOFF}
+        <FilterPot x={col3} y={centerRow} ledMode="single" label="Cutoff" Large
+                   selector={s => s.filters[FILTER].cutoff}
+                   mutator={(s, v) => { s.filters[FILTER].cutoff = v }}
         />
 
-        <RotaryPot12 x={col1} y={topRow} ledMode="multi" label="In dry/wet"
-                     ctrlGroup={ctrlGroup}
-                     ctrl={filtersControllers.SVF.INPUT}
+        <FilterPot x={col1} y={topRow} label="In dry/wet"
+                   selector={s => s.filters[FILTER].input}
+                   mutator={(s, v) => { s.filters[FILTER].input = v }}
         />
 
-        <RotaryPot12 x={col3} y={topRow} ledMode="multi" label="Resonance"
-                     ctrlGroup={ctrlGroup}
-                     ctrl={filtersControllers.SVF.RESONANCE}
+        <FilterPot x={col3} y={topRow} label="Resonance"
+                   selector={s => s.filters[FILTER].resonance}
+                   mutator={(s, v) => { s.filters[FILTER].resonance = v }}
         />
 
-        <RotaryPot12 x={col5} y={topRow} ledMode="multi" label="FM"
-                     ctrlGroup={ctrlGroup}
-                     ctrl={filtersControllers.SVF.FM_AMT}
+        <FilterPot x={col5} y={topRow} label="FM"
+                   selector={s => s.filters[FILTER].fmAmt}
+                   mutator={(s, v) => { s.filters[FILTER].fmAmt = v }}
         />
 
 
         <RoundPushButton8 x={col1} y={fmRow} ledPosition="top" ledCount={2} ledLabels={['Lin', 'Log']}
                           label="FM mode" labelPosition="bottom"
                           hasOff
-                          ctrlGroup={ctrlGroup}
-                          ctrl={filtersControllers.SVF.FM_MODE}
+                          value={fmModeValue}
+                          onButtonClick={fmModeToggle}
         />
 
         <RoundPushButton8 x={col5} y={fmRow} ledPosition="top" ledCount={2} ledLabels={['2', 'Ext']}
                           label="FM src" labelPosition="bottom"
-                          ctrlGroup={ctrlGroup}
-                          ctrl={filtersControllers.SVF.FM_SRC}
+                          value={fmSrcValue}
+                          onButtonClick={fmSrcToggle}
         />
 
         {/*<RoundLedPushButton8 x={col4} y={y + 10} label="Ext CV" labelPosition="bottom"
@@ -97,20 +137,20 @@ const StateVariableFilter = ({ x, y, height, width }: ModuleProps) => {
                                  '12dB HP', '24dB HP', 'HP + BP', 'Notch', 'AP'
                              ]}
                              resolution={10}
-                             ctrlGroup={ctrlGroup}
-                             ctrl={filtersControllers.SVF.SLOPE}
+                             value={slopeValue}
+                             onButtonClick={slopeToggle}
         />
 
         <HorizontalDividerLine x={x} y={bottomRow2 - 12.5} width={width}/>
 
-        <RotaryPot12 x={col1} y={bottomRow2} ledMode="multi" label="Keyboard"
-                     ctrlGroup={ctrlGroup}
-                     ctrl={filtersControllers.SVF.KBD_AMT}
+        <FilterPot x={col1} y={bottomRow2} label="Keyboard"
+                   selector={s => s.filters[FILTER].kbdAmt}
+                   mutator={(s, v) => { s.filters[FILTER].kbdAmt = v }}
         />
 
-        <RotaryPot12 x={col2} y={bottomRow2} ledMode="multi" label="LFO"
-                     ctrlGroup={ctrlGroup}
-                     ctrl={filtersControllers.SVF.LFO_AMT}
+        <FilterPot x={col2} y={bottomRow2} label="LFO"
+                   selector={s => s.filters[FILTER].lfoAmt}
+                   mutator={(s, v) => { s.filters[FILTER].lfoAmt = v }}
         />
 
         <RotaryPot12 x={col4} y={bottomRow2} ledMode="multi" label="Wheel"
@@ -118,14 +158,14 @@ const StateVariableFilter = ({ x, y, height, width }: ModuleProps) => {
                      ctrl={filtersControllers.SVF.WHEEL_AMT}
         />
 
-        <RotaryPot12 x={col5} y={bottomRow2} ledMode="multi" label="Envelope"
-                     ctrlGroup={ctrlGroup}
-                     ctrl={filtersControllers.SVF.ENV_AMT}
+        <FilterPot x={col5} y={bottomRow2} label="Envelope"
+                   selector={s => s.filters[FILTER].envAmt}
+                   mutator={(s, v) => { s.filters[FILTER].envAmt = v }}
         />
 
         <RoundLedPushButton8 x={col5} y={bottomRow1 + 5} label="Invert" labelPosition="bottom"
-                             ctrlGroup={ctrlGroup}
-                             ctrl={filtersControllers.SVF.INVERT}
+                             value={invertValue}
+                             onButtonClick={invertToggle}
         />
 
     </>

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -14,6 +14,7 @@ import { startFxKbdMidiSend, startFxKbdMidiReceive } from './store/midi/fxKbdMid
 import { startSrcMixMidiSend, startSrcMixMidiReceive } from './store/midi/srcMixMidi'
 import { startOutPostMixMidiSend, startOutPostMixMidiReceive } from './store/midi/outMidi'
 import { startOscMidiSend, startOscMidiReceive } from './store/midi/oscMidi'
+import { startFilterMidiSend, startFilterMidiReceive } from './store/midi/filterMidi'
 
 midiApi.initReceive()
 startEnvelopeMidiSend()
@@ -28,6 +29,8 @@ startOutPostMixMidiSend()
 startOutPostMixMidiReceive()
 startOscMidiSend()
 startOscMidiReceive()
+startFilterMidiSend()
+startFilterMidiReceive()
 
 const root = ReactDOM.createRoot(
   document.getElementById('root') as HTMLElement

--- a/src/store/midi/filterMidi.ts
+++ b/src/store/midi/filterMidi.ts
@@ -1,0 +1,140 @@
+/**
+ * MIDI send/receive for filters: subscribes to Zustand store changes
+ * and sends changed parameters over MIDI, and subscribes to midibus to
+ * write incoming MIDI values to the Zustand stores.
+ *
+ * Handles both filters: LPF (index 0) and SVF (index 1).
+ */
+
+import { voiceGroupStores, FilterState } from '../patchStore'
+import { cc, button } from '../../midi/midibus'
+import { ControllerConfigCC, ControllerConfigButton } from '../../midi/types'
+import filtersControllers from '../../synthcore/modules/filters/filtersControllers'
+import { isMidiReceiving, withMidiReceive } from './midiGuard'
+
+type FilterField = keyof FilterState
+
+interface CCMapping {
+    filterIndex: number
+    field: FilterField
+    ctrl: ControllerConfigCC
+}
+
+interface ButtonMapping {
+    filterIndex: number
+    field: FilterField
+    ctrl: ControllerConfigButton
+}
+
+const ccMappings: CCMapping[] = [
+    // LPF
+    { filterIndex: 0, field: 'input', ctrl: filtersControllers.LPF.INPUT },
+    { filterIndex: 0, field: 'resonance', ctrl: filtersControllers.LPF.RESONANCE },
+    { filterIndex: 0, field: 'cutoff', ctrl: filtersControllers.LPF.CUTOFF },
+    { filterIndex: 0, field: 'fmAmt', ctrl: filtersControllers.LPF.FM_AMT },
+    { filterIndex: 0, field: 'envAmt', ctrl: filtersControllers.LPF.ENV_AMT },
+    { filterIndex: 0, field: 'lfoAmt', ctrl: filtersControllers.LPF.LFO_AMT },
+    { filterIndex: 0, field: 'kbdAmt', ctrl: filtersControllers.LPF.KBD_AMT },
+    // SVF
+    { filterIndex: 1, field: 'input', ctrl: filtersControllers.SVF.INPUT },
+    { filterIndex: 1, field: 'resonance', ctrl: filtersControllers.SVF.RESONANCE },
+    { filterIndex: 1, field: 'cutoff', ctrl: filtersControllers.SVF.CUTOFF },
+    { filterIndex: 1, field: 'fmAmt', ctrl: filtersControllers.SVF.FM_AMT },
+    { filterIndex: 1, field: 'envAmt', ctrl: filtersControllers.SVF.ENV_AMT },
+    { filterIndex: 1, field: 'lfoAmt', ctrl: filtersControllers.SVF.LFO_AMT },
+    { filterIndex: 1, field: 'kbdAmt', ctrl: filtersControllers.SVF.KBD_AMT },
+]
+
+const buttonMappings: ButtonMapping[] = [
+    // LPF
+    { filterIndex: 0, field: 'fmMode', ctrl: filtersControllers.LPF.FM_MODE },
+    { filterIndex: 0, field: 'filterType', ctrl: filtersControllers.LPF.FILTER_TYPE },
+    { filterIndex: 0, field: 'slope', ctrl: filtersControllers.LPF.SLOPE },
+    { filterIndex: 0, field: 'fmSrc', ctrl: filtersControllers.LPF.FM_SRC },
+    { filterIndex: 0, field: 'extCv', ctrl: filtersControllers.LPF.EXT_CV },
+    // SVF
+    { filterIndex: 1, field: 'fmMode', ctrl: filtersControllers.SVF.FM_MODE },
+    { filterIndex: 1, field: 'slope', ctrl: filtersControllers.SVF.SLOPE },
+    { filterIndex: 1, field: 'fmSrc', ctrl: filtersControllers.SVF.FM_SRC },
+    { filterIndex: 1, field: 'invert', ctrl: filtersControllers.SVF.INVERT },
+    { filterIndex: 1, field: 'extCv', ctrl: filtersControllers.SVF.EXT_CV },
+    // Shared (stored on filters[0])
+    { filterIndex: 0, field: 'linkCutoff', ctrl: filtersControllers.FILTERS.LINK_CUTOFF },
+    { filterIndex: 0, field: 'routing', ctrl: filtersControllers.FILTERS.ROUTING },
+]
+
+let sendUnsubscribers: (() => void)[] = []
+let receiveUnsubscribers: (() => void)[] = []
+
+export function startFilterMidiSend() {
+    stopFilterMidiSend()
+
+    voiceGroupStores.forEach((store, voiceGroupIndex) => {
+        let previousFilters = store.getState().filters
+
+        const unsub = store.subscribe((state) => {
+            if (isMidiReceiving()) {
+                previousFilters = state.filters
+                return
+            }
+            if (state.filters !== previousFilters) {
+                const prev = previousFilters
+                previousFilters = state.filters
+
+                for (const { filterIndex, field, ctrl } of ccMappings) {
+                    if (state.filters[filterIndex][field] !== prev[filterIndex][field]) {
+                        cc.send(voiceGroupIndex, ctrl, Math.floor(127 * state.filters[filterIndex][field]))
+                    }
+                }
+
+                for (const { filterIndex, field, ctrl } of buttonMappings) {
+                    if (state.filters[filterIndex][field] !== prev[filterIndex][field]) {
+                        button.send(voiceGroupIndex, ctrl, ctrl.values[state.filters[filterIndex][field]])
+                    }
+                }
+            }
+        })
+
+        sendUnsubscribers.push(unsub)
+    })
+}
+
+export function stopFilterMidiSend() {
+    sendUnsubscribers.forEach(unsub => unsub())
+    sendUnsubscribers = []
+}
+
+export function startFilterMidiReceive() {
+    stopFilterMidiReceive()
+
+    for (const { filterIndex, field, ctrl } of ccMappings) {
+        const id = cc.subscribe((voiceGroupIndex: number, midiValue: number) => {
+            const value = midiValue / 127
+            withMidiReceive(() => {
+                voiceGroupStores[voiceGroupIndex].getState().set(state => {
+                    state.filters[filterIndex][field] = value
+                })
+            })
+        }, ctrl)
+        receiveUnsubscribers.push(() => cc.unsubscribe(ctrl, id))
+    }
+
+    for (const { filterIndex, field, ctrl } of buttonMappings) {
+        const id = button.subscribe((voiceGroupIndex: number, midiValue: number) => {
+            const value = ctrl.values.indexOf(midiValue)
+            if (value < 0) return
+
+            withMidiReceive(() => {
+                voiceGroupStores[voiceGroupIndex].getState().set(state => {
+                    state.filters[filterIndex][field] = value
+                })
+            })
+        }, ctrl)
+        receiveUnsubscribers.push(() => button.unsubscribe(ctrl, id))
+    }
+}
+
+export function stopFilterMidiReceive() {
+    receiveUnsubscribers.forEach(unsub => unsub())
+    receiveUnsubscribers = []
+}

--- a/src/store/patchStore.ts
+++ b/src/store/patchStore.ts
@@ -98,6 +98,9 @@ export interface FilterState {
     fmMode: number
     filterType: number
     fmSrc: number
+    invert: number
+    linkCutoff: number
+    routing: number
 }
 
 export interface SrcMixState {
@@ -331,6 +334,9 @@ const defaultFilter = (): FilterState => ({
     fmMode: 0,
     filterType: 0,
     fmSrc: 0,
+    invert: 0,
+    linkCutoff: 0,
+    routing: 0,
 })
 
 export const defaultVoiceGroupPatch = (): VoiceGroupPatch => ({


### PR DESCRIPTION
## Summary
- Add `invert`, `linkCutoff`, `routing` fields to `FilterState` in patchStore
- Rewrite LowPassFilter and StateVariableFilter to use `usePot`/`useButton` Zustand hooks
- Shared params (link cutoff, routing) stored on filters[0] by convention
- WHEEL_AMT stays on old ctrlGroup/ctrl pattern (NRPN, deferred)
- Add MIDI send/receive for all CC pots and button params across both filters
- 12 new tests covering filter CC and button MIDI send/receive

## Notes
- SVF slope uses RoundRotaryButton17 with 10 discrete values (useButton with numValues=10)
- LPF-specific fields (filterType) unused on SVF, SVF-specific (invert) unused on LPF

## Test plan
- [x] All 165 tests pass, no regressions
- [ ] Verify LPF pots (cutoff, resonance, input, FM, env/lfo/kbd amounts) respond in UI
- [ ] Verify SVF pots and 10-way slope selector respond in UI
- [ ] Verify shared routing/link cutoff buttons
- [ ] Verify MIDI send/receive for all filter parameters

🤖 Generated with [Claude Code](https://claude.com/claude-code)