### PR TITLE
Wire LFO to Zustand with MIDI send/receive

### DIFF
--- a/src/__tests__/store/lfoMidi.test.ts
+++ b/src/__tests__/store/lfoMidi.test.ts
@@ -1,0 +1,144 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+
+vi.mock('../../synthcore/synthcoreMiddleware', () => ({
+    synthcoreMiddleware: () => (next: any) => (action: any) => next(action),
+}))
+
+import { cc, nrpn, button } from '../../midi/midibus'
+import { voiceGroupStores, createPatchStore } from '../../store/patchStore'
+import { lfoCtrls } from '../../synthcore/modules/lfo/lfoControllers'
+import { buttonMidiValues } from '../../midi/buttonMidiValues'
+import { startLfoMidiReceive, stopLfoMidiReceive, startLfoMidiSend, stopLfoMidiSend } from '../../store/midi/lfoMidi'
+
+const VG = 0
+const LFO = 1
+
+function selectLfo(lfoId: number) {
+    cc.publish(VG, (lfoCtrls.SELECT as any).cc, lfoId)
+}
+
+function getLfo(lfoId = LFO) {
+    return voiceGroupStores[VG].getState().lfos[lfoId]
+}
+
+function resetStore() {
+    const fresh = createPatchStore()
+    voiceGroupStores[VG].getState().loadPatch(fresh.getState().getPatch())
+}
+
+describe('LFO MIDI receive', () => {
+    beforeEach(() => {
+        resetStore()
+        startLfoMidiReceive()
+        selectLfo(LFO)
+    })
+
+    afterEach(() => {
+        stopLfoMidiReceive()
+    })
+
+    it('sets rate from NRPN', () => {
+        const midiValue = Math.floor(65535 * 0.75)
+        nrpn.publish(VG, lfoCtrls.RATE.addr, midiValue)
+        expect(getLfo().rate).toBeCloseTo(0.75, 3)
+    })
+
+    it('sets depth from NRPN', () => {
+        const midiValue = Math.floor(65535 * 0.5)
+        nrpn.publish(VG, lfoCtrls.DEPTH.addr, midiValue)
+        expect(getLfo().depth).toBeCloseTo(0.5, 3)
+    })
+
+    it('sets levelOffset from NRPN (bipolar)', () => {
+        const midiValue = Math.floor(32767 * -0.5 + 32767)
+        nrpn.publish(VG, lfoCtrls.LEVEL_OFFSET.addr, midiValue)
+        expect(getLfo().levelOffset).toBeCloseTo(-0.5, 2)
+    })
+
+    it('sets shape from button MIDI', () => {
+        button.publish(VG, buttonMidiValues.LFO_SHAPE_SQR)
+        expect(getLfo().shape).toBe(2)
+    })
+
+    it('sets sync from button MIDI', () => {
+        button.publish(VG, buttonMidiValues.LFO_SYNC_ON)
+        expect(getLfo().sync).toBe(1)
+    })
+
+    it('sets bipolar from button MIDI', () => {
+        button.publish(VG, buttonMidiValues.LFO_BIPOLAR_ON)
+        expect(getLfo().bipolar).toBe(1)
+    })
+
+    it('sets maxLoops from CC', () => {
+        cc.publish(VG, (lfoCtrls.MAX_LOOPS as any).cc, 10)
+        expect(getLfo().maxLoops).toBe(10)
+    })
+
+    it('targets correct LFO after select', () => {
+        selectLfo(2)
+        button.publish(VG, buttonMidiValues.LFO_INVERT_ON)
+        expect(voiceGroupStores[VG].getState().lfos[2].invert).toBe(1)
+        expect(getLfo().invert).toBe(0)
+    })
+})
+
+describe('LFO MIDI send', () => {
+    let sentNrpn: { addr: number, value: number }[] = []
+    let sentCC: { ccNum: number, value: number }[] = []
+    let sentButtons: { ctrl: any, value: number }[] = []
+    const origNrpnSend = nrpn.send
+    const origCCSend = cc.send
+    const origButtonSend = button.send
+
+    beforeEach(() => {
+        resetStore()
+        sentNrpn = []
+        sentCC = []
+        sentButtons = []
+        nrpn.send = vi.fn((vg, ctrl, value) => {
+            sentNrpn.push({ addr: ctrl.addr, value })
+        }) as any
+        cc.send = vi.fn((vg, ctrl, value) => {
+            sentCC.push({ ccNum: ctrl.cc, value })
+        }) as any
+        button.send = vi.fn((vg, ctrl, value) => {
+            sentButtons.push({ ctrl, value })
+        }) as any
+        startLfoMidiSend()
+    })
+
+    afterEach(() => {
+        stopLfoMidiSend()
+        nrpn.send = origNrpnSend
+        cc.send = origCCSend
+        button.send = origButtonSend
+    })
+
+    it('sends rate change as NRPN', () => {
+        voiceGroupStores[VG].getState().set(s => { s.lfos[0].rate = 0.3 })
+        const sent = sentNrpn.find(s => s.addr === lfoCtrls.RATE.addr)
+        expect(sent).toBeDefined()
+        expect(sent!.value).toBe(Math.floor(65535 * 0.3))
+    })
+
+    it('sends LFO select CC before param', () => {
+        voiceGroupStores[VG].getState().set(s => { s.lfos[2].depth = 0.8 })
+        const selectSent = sentCC.find(s => s.ccNum === (lfoCtrls.SELECT as any).cc)
+        expect(selectSent).toBeDefined()
+        expect(selectSent!.value).toBe(2)
+    })
+
+    it('sends shape change as button MIDI', () => {
+        voiceGroupStores[VG].getState().set(s => { s.lfos[0].shape = 3 })
+        const sent = sentButtons.find(s => s.value === buttonMidiValues.LFO_SHAPE_SIN)
+        expect(sent).toBeDefined()
+    })
+
+    it('sends levelOffset as bipolar NRPN', () => {
+        voiceGroupStores[VG].getState().set(s => { s.lfos[0].levelOffset = -0.5 })
+        const sent = sentNrpn.find(s => s.addr === lfoCtrls.LEVEL_OFFSET.addr)
+        expect(sent).toBeDefined()
+        expect(sent!.value).toBe(Math.floor(32767 * -0.5 + 32767))
+    })
+})

--- a/src/components/modules/left2/LFO.tsx
+++ b/src/components/modules/left2/LFO.tsx
@@ -1,11 +1,7 @@
-import React from 'react'
+import React, { useCallback } from 'react'
 import RotaryPot12 from '../../pots/RotaryPot12'
 import RoundLedPushButton8 from '../../buttons/RoundLedPushButton8'
 import RoundPushButton8 from '../../buttons/RoundPushButton8'
-import { ControllerGroupIds } from '../../../synthcore/types'
-import { useAppSelector } from '../../../synthcore/hooks'
-import { lfoCtrls } from '../../../synthcore/modules/lfo/lfoControllers'
-import { selectCurrUiLfoId } from '../../../synthcore/modules/lfo/lfoReducer'
 import SubHeader from "../../misc/SubHeader";
 import {
     BUTTON_DISTANCE_S,
@@ -13,18 +9,16 @@ import {
     POT_OFFSET_Y,
     ROW_HEIGHT,
 } from "../../../constants";
-import { SHOW_CUT } from "../../../config";
 import { ModuleBorder } from "../../misc/ModuleBorder";
 import { ModuleProps } from "../types";
-import { SawLeft } from "../../images/SawLeft";
 import { SawRight } from "../../images/SawRight";
 import { Triangle } from "../../images/Triangle";
 import { Square } from "../../images/Square";
 import { Sine } from "../../images/Sine";
 import { Random } from "../../images/Random";
-
-const ctrlGroup = ControllerGroupIds.LFO
-
+import { usePot, useButton } from '../../../store/hooks'
+import { useUiStore } from '../../../store/uiStore'
+import { timeResponseMapper } from '../../../synthcore/modules/common/responseMappers'
 
 const LFO = ({ x, y, height, width }: ModuleProps) => {
     const col1 = x + POT_DISTANCE_M / 2
@@ -36,8 +30,61 @@ const LFO = ({ x, y, height, width }: ModuleProps) => {
     const row1 = y + POT_OFFSET_Y
     const row2 = row1 + ROW_HEIGHT
 
-    const lfoId = useAppSelector(selectCurrUiLfoId)
+    const lfoId = useUiStore(s => s.selectedLfoId)
+    const selectLfo = useUiStore(s => s.selectLfo)
 
+    const onSelectLfo = useCallback(() => {
+        selectLfo((lfoId + 1) % 3)
+    }, [lfoId, selectLfo])
+
+    const { displayValue: rateValue, increment: rateIncrement } = usePot(
+        s => s.lfos[lfoId].rate,
+        (s, v) => { s.lfos[lfoId].rate = v },
+        { responseMapper: timeResponseMapper }
+    )
+    const { displayValue: depthValue, increment: depthIncrement } = usePot(
+        s => s.lfos[lfoId].depth,
+        (s, v) => { s.lfos[lfoId].depth = v }
+    )
+    const { displayValue: balanceValue, increment: balanceIncrement } = usePot(
+        s => s.lfos[lfoId].balance,
+        (s, v) => { s.lfos[lfoId].balance = v }
+    )
+    const { displayValue: delayValue, increment: delayIncrement } = usePot(
+        s => s.lfos[lfoId].delay,
+        (s, v) => { s.lfos[lfoId].delay = v },
+        { responseMapper: timeResponseMapper }
+    )
+    const { value: shapeValue, toggle: shapeToggle } = useButton(
+        s => s.lfos[lfoId].shape,
+        (s, v) => { s.lfos[lfoId].shape = v },
+        6
+    )
+    const { value: syncValue, toggle: syncToggle } = useButton(
+        s => s.lfos[lfoId].sync,
+        (s, v) => { s.lfos[lfoId].sync = v },
+        2
+    )
+    const { value: resetValue, toggle: resetToggle } = useButton(
+        s => s.lfos[lfoId].reset,
+        (s, v) => { s.lfos[lfoId].reset = v },
+        2
+    )
+    const { value: loopValue, toggle: loopToggle } = useButton(
+        s => s.lfos[lfoId].loop,
+        (s, v) => { s.lfos[lfoId].loop = v },
+        2
+    )
+    const { value: invertValue, toggle: invertToggle } = useButton(
+        s => s.lfos[lfoId].invert,
+        (s, v) => { s.lfos[lfoId].invert = v },
+        2
+    )
+    const { value: bipolarValue, toggle: bipolarToggle } = useButton(
+        s => s.lfos[lfoId].bipolar,
+        (s, v) => { s.lfos[lfoId].bipolar = v },
+        2
+    )
 
     return <>
         {/*!SHOW_CUT && <rect x={x} y={y} width={323} height={ROW_HEIGHT * 2- ROW_SPACING} className="module-background"/>*/}
@@ -45,75 +92,58 @@ const LFO = ({ x, y, height, width }: ModuleProps) => {
         <SubHeader align="left" label="LFO" labelPosition="center" x={x} y={y} width={width} labelWidth={15}/>
 
         <RoundLedPushButton8 label="Sync" x={col1} y={row1} labelPosition="bottom-pot"
-                             ctrlGroup={ctrlGroup}
-                             ctrl={lfoCtrls.SYNC}
-                             ctrlIndex={lfoId}
+                             value={syncValue}
+                             onButtonClick={syncToggle}
         />
 
-        {/* TODO: Allow more than 3 LFOs from the main menu but not here */}
         <RoundPushButton8 x={col1} y={row2}
                           label="LFO"
                           labelPosition="bottom-pot"
                           ledPosition="right" ledCount={3}
                           ledLabels={['1', '2', '3']}
-                          ctrlGroup={ctrlGroup}
-                          ctrl={lfoCtrls.LFO}
-                          ctrlIndex={0}
                           value={lfoId}
+                          onButtonClick={onSelectLfo}
         />
 
         <RotaryPot12 ledMode="single" label="Rate" x={col2} y={row1}
-                     ctrlGroup={ctrlGroup}
-                     ctrl={lfoCtrls.RATE}
-                     ctrlIndex={lfoId}
+                     value={rateValue}
+                     onValueIncrement={rateIncrement}
         />
 
-
         <RotaryPot12 ledMode="single" label="Depth" x={col3} y={row1}
-                     ctrlGroup={ctrlGroup}
-                     ctrl={lfoCtrls.DEPTH}
-                     ctrlIndex={lfoId}
+                     value={depthValue}
+                     onValueIncrement={depthIncrement}
         />
 
         <RotaryPot12 ledMode="single" label="Balance" x={col4} y={row1}
-                     ctrlGroup={ctrlGroup}
-                     ctrl={lfoCtrls.BALANCE}
-                     ctrlIndex={lfoId}
+                     value={balanceValue}
+                     onValueIncrement={balanceIncrement}
         />
 
         <RotaryPot12 ledMode="single" label="Delay" x={col5} y={row1}
-                     ctrlGroup={ctrlGroup}
-                     ctrl={lfoCtrls.DELAY}
-                     ctrlIndex={lfoId}
+                     value={delayValue}
+                     onValueIncrement={delayIncrement}
         />
 
         <RoundLedPushButton8 label="Bipolar" x={col2} y={row2} labelPosition="bottom-pot"
-                             ctrlGroup={ctrlGroup}
-                             ctrl={lfoCtrls.BIPOLAR}
-                             ctrlIndex={lfoId}
-                             loop
+                             value={bipolarValue}
+                             onButtonClick={bipolarToggle}
         />
 
         <RoundLedPushButton8 label="Invert" x={col2 + BUTTON_DISTANCE_S} y={row2} labelPosition="bottom-pot"
-                             ctrlGroup={ctrlGroup}
-                             ctrl={lfoCtrls.INVERT}
-                             ctrlIndex={lfoId}
-                             loop
+                             value={invertValue}
+                             onButtonClick={invertToggle}
         />
 
         <RoundLedPushButton8 label="Loop" x={col2 + BUTTON_DISTANCE_S * 2} y={row2} labelPosition="bottom-pot"
-                             ctrlGroup={ctrlGroup}
-                             ctrl={lfoCtrls.LOOP}
-                             ctrlIndex={lfoId}
-                             loop
+                             value={loopValue}
+                             onButtonClick={loopToggle}
         />
 
         <RoundLedPushButton8 label="Reset" x={col2 + BUTTON_DISTANCE_S * 3} y={row2} labelPosition="bottom-pot"
-                             ctrlGroup={ctrlGroup}
-                             ctrl={lfoCtrls.RESET}
-                             ctrlIndex={lfoId}
+                             value={resetValue}
+                             onButtonClick={resetToggle}
         />
-
 
         <RoundPushButton8 x={col2 + BUTTON_DISTANCE_S * 4} y={row2}
                           label="Shape" labelPosition="bottom-pot"
@@ -126,17 +156,11 @@ const LFO = ({ x, y, height, width }: ModuleProps) => {
                               <Random x={0} y={0} width={3} height={2}/>,
                               'Other'
                           ]}
-                          ctrlGroup={ctrlGroup}
-                          ctrl={lfoCtrls.SHAPE}
-                          ctrlIndex={lfoId}
+                          value={shapeValue}
+                          onButtonClick={shapeToggle}
         />
 
-
         <RoundPushButton8 label="Trigger" x={col2 + BUTTON_DISTANCE_S * 6} y={row1} labelPosition="bottom-pot"
-                          ctrlGroup={ctrlGroup}
-                          ctrl={lfoCtrls.GATE}
-                          ctrlIndex={lfoId}
-                          loop
         />
 
     </>

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -15,6 +15,7 @@ import { startSrcMixMidiSend, startSrcMixMidiReceive } from './store/midi/srcMix
 import { startOutPostMixMidiSend, startOutPostMixMidiReceive } from './store/midi/outMidi'
 import { startOscMidiSend, startOscMidiReceive } from './store/midi/oscMidi'
 import { startFilterMidiSend, startFilterMidiReceive } from './store/midi/filterMidi'
+import { startLfoMidiSend, startLfoMidiReceive } from './store/midi/lfoMidi'
 
 midiApi.initReceive()
 startEnvelopeMidiSend()
@@ -31,6 +32,8 @@ startOscMidiSend()
 startOscMidiReceive()
 startFilterMidiSend()
 startFilterMidiReceive()
+startLfoMidiSend()
+startLfoMidiReceive()
 
 const root = ReactDOM.createRoot(
   document.getElementById('root') as HTMLElement

--- a/src/store/midi/lfoMidi.ts
+++ b/src/store/midi/lfoMidi.ts
@@ -1,0 +1,189 @@
+import { voiceGroupStores, LfoState } from '../patchStore'
+import { cc, nrpn, button } from '../../midi/midibus'
+import { ControllerConfigCC, ControllerConfigNRPN, ControllerConfigButton } from '../../midi/types'
+import { lfoCtrls } from '../../synthcore/modules/lfo/lfoControllers'
+import { isMidiReceiving, withMidiReceive } from './midiGuard'
+
+const NUMBER_OF_LFOS = 4
+
+type LfoField = keyof Omit<LfoState, 'stages'>
+
+interface NrpnMapping {
+    field: LfoField
+    ctrl: ControllerConfigNRPN
+    bipolar?: boolean
+}
+
+interface ButtonMapping {
+    field: LfoField
+    ctrl: ControllerConfigButton
+}
+
+const nrpnMappings: NrpnMapping[] = [
+    { field: 'rate', ctrl: lfoCtrls.RATE },
+    { field: 'depth', ctrl: lfoCtrls.DEPTH },
+    { field: 'delay', ctrl: lfoCtrls.DELAY },
+    { field: 'balance', ctrl: lfoCtrls.BALANCE },
+    { field: 'phaseOffset', ctrl: lfoCtrls.PHASE_OFFSET },
+    { field: 'levelOffset', ctrl: lfoCtrls.LEVEL_OFFSET, bipolar: true },
+]
+
+const buttonMappings: ButtonMapping[] = [
+    { field: 'shape', ctrl: lfoCtrls.SHAPE },
+    { field: 'sync', ctrl: lfoCtrls.SYNC },
+    { field: 'reset', ctrl: lfoCtrls.RESET },
+    { field: 'bipolar', ctrl: lfoCtrls.BIPOLAR },
+    { field: 'invert', ctrl: lfoCtrls.INVERT },
+    { field: 'loop', ctrl: lfoCtrls.LOOP },
+    { field: 'loopMode', ctrl: lfoCtrls.LOOP_MODE },
+    { field: 'resetOnTrigger', ctrl: lfoCtrls.RESET_ON_TRIGGER },
+    { field: 'resetOnStop', ctrl: lfoCtrls.RESET_ON_STOP },
+    { field: 'resetLevelOnClock', ctrl: lfoCtrls.RESET_LEVEL_ON_CLOCK },
+    { field: 'syncToClock', ctrl: lfoCtrls.SYNC_TO_CLOCK },
+    { field: 'gated', ctrl: lfoCtrls.GATED },
+]
+
+let currentSentLfoId = -1
+
+function sendLfoSelect(voiceGroupIndex: number, lfoId: number) {
+    if (lfoId !== currentSentLfoId) {
+        currentSentLfoId = lfoId
+        cc.send(voiceGroupIndex, lfoCtrls.SELECT as ControllerConfigCC, lfoId)
+    }
+}
+
+function sendLfoParams(
+    voiceGroupIndex: number,
+    lfoId: number,
+    lfo: LfoState,
+    prevLfo: LfoState
+) {
+    let selectSent = false
+    const ensureSelect = () => {
+        if (!selectSent) {
+            sendLfoSelect(voiceGroupIndex, lfoId)
+            selectSent = true
+        }
+    }
+
+    for (const m of nrpnMappings) {
+        if (lfo[m.field] !== prevLfo[m.field]) {
+            ensureSelect()
+            const value = lfo[m.field]
+            const midiValue = m.bipolar
+                ? Math.floor(32767 * value + 32767)
+                : Math.floor(65535 * value)
+            nrpn.send(voiceGroupIndex, m.ctrl, midiValue)
+        }
+    }
+
+    if (lfo.maxLoops !== prevLfo.maxLoops) {
+        ensureSelect()
+        cc.send(voiceGroupIndex, lfoCtrls.MAX_LOOPS as ControllerConfigCC, lfo.maxLoops)
+    }
+
+    for (const m of buttonMappings) {
+        if (lfo[m.field] !== prevLfo[m.field]) {
+            ensureSelect()
+            button.send(voiceGroupIndex, m.ctrl, m.ctrl.values[lfo[m.field]])
+        }
+    }
+}
+
+let sendUnsubscribers: (() => void)[] = []
+
+export function startLfoMidiSend() {
+    stopLfoMidiSend()
+
+    voiceGroupStores.forEach((store, voiceGroupIndex) => {
+        let previousLfos = store.getState().lfos
+
+        const unsub = store.subscribe((state) => {
+            if (isMidiReceiving()) {
+                previousLfos = state.lfos
+                return
+            }
+            if (state.lfos !== previousLfos) {
+                const prev = previousLfos
+                previousLfos = state.lfos
+
+                for (let lfoId = 0; lfoId < NUMBER_OF_LFOS; lfoId++) {
+                    if (state.lfos[lfoId] !== prev[lfoId]) {
+                        sendLfoParams(voiceGroupIndex, lfoId, state.lfos[lfoId], prev[lfoId])
+                    }
+                }
+            }
+        })
+
+        sendUnsubscribers.push(unsub)
+    })
+}
+
+export function stopLfoMidiSend() {
+    sendUnsubscribers.forEach(unsub => unsub())
+    sendUnsubscribers = []
+    currentSentLfoId = -1
+}
+
+let currentReceivedLfoId = -1
+let receiveUnsubscribers: (() => void)[] = []
+
+function subscribeLfoSelect() {
+    const cfg = lfoCtrls.SELECT as ControllerConfigCC
+    const id = cc.subscribe((voiceGroupIndex: number, value: number) => {
+        currentReceivedLfoId = value
+    }, cfg)
+    return () => cc.unsubscribe(cfg, id)
+}
+
+export function startLfoMidiReceive() {
+    stopLfoMidiReceive()
+
+    receiveUnsubscribers.push(subscribeLfoSelect())
+
+    for (const m of nrpnMappings) {
+        const id = nrpn.subscribe((voiceGroupIndex: number, midiValue: number) => {
+            if (currentReceivedLfoId < 0) return
+            const value = m.bipolar
+                ? (midiValue - 32767) / 32767
+                : midiValue / 65535
+            withMidiReceive(() => {
+                voiceGroupStores[voiceGroupIndex].getState().set(state => {
+                    state.lfos[currentReceivedLfoId][m.field] = value
+                })
+            })
+        }, m.ctrl)
+        receiveUnsubscribers.push(() => nrpn.unsubscribe(m.ctrl, id))
+    }
+
+    const maxLoopsCtrl = lfoCtrls.MAX_LOOPS as ControllerConfigCC
+    const mlId = cc.subscribe((voiceGroupIndex: number, midiValue: number) => {
+        if (currentReceivedLfoId < 0) return
+        withMidiReceive(() => {
+            voiceGroupStores[voiceGroupIndex].getState().set(state => {
+                state.lfos[currentReceivedLfoId].maxLoops = midiValue
+            })
+        })
+    }, maxLoopsCtrl)
+    receiveUnsubscribers.push(() => cc.unsubscribe(maxLoopsCtrl, mlId))
+
+    for (const m of buttonMappings) {
+        const id = button.subscribe((voiceGroupIndex: number, midiValue: number) => {
+            if (currentReceivedLfoId < 0) return
+            const value = m.ctrl.values.indexOf(midiValue)
+            if (value < 0) return
+            withMidiReceive(() => {
+                voiceGroupStores[voiceGroupIndex].getState().set(state => {
+                    state.lfos[currentReceivedLfoId][m.field] = value
+                })
+            })
+        }, m.ctrl)
+        receiveUnsubscribers.push(() => button.unsubscribe(m.ctrl, id))
+    }
+}
+
+export function stopLfoMidiReceive() {
+    receiveUnsubscribers.forEach(unsub => unsub())
+    receiveUnsubscribers = []
+    currentReceivedLfoId = -1
+}

--- a/src/store/patchStore.ts
+++ b/src/store/patchStore.ts
@@ -54,6 +54,21 @@ export interface LfoState {
     delay: number
     shape: number
     sync: number
+    balance: number
+    phaseOffset: number
+    levelOffset: number
+    bipolar: number
+    invert: number
+    reset: number
+    loop: number
+    loopMode: number
+    maxLoops: number
+    resetOnTrigger: number
+    resetOnStop: number
+    resetLevelOnClock: number
+    syncToClock: number
+    gated: number
+    randomPhase: number
     stages: {
         [stageId: number]: LfoStageState
     }
@@ -292,6 +307,21 @@ const defaultLfo = (): LfoState => ({
     delay: 0,
     shape: 0,
     sync: 0,
+    balance: 0.5,
+    phaseOffset: 0,
+    levelOffset: 0,
+    bipolar: 0,
+    invert: 0,
+    reset: 0,
+    loop: 0,
+    loopMode: 0,
+    maxLoops: 2,
+    resetOnTrigger: 0,
+    resetOnStop: 0,
+    resetLevelOnClock: 0,
+    syncToClock: 0,
+    gated: 0,
+    randomPhase: 0,
     stages: {},
 })
 


### PR DESCRIPTION
## Summary
- Add missing fields to `LfoState` that were still handled by the generic Redux controller store: balance, phaseOffset, levelOffset, bipolar, invert, reset, loop, loopMode, maxLoops, resetOnTrigger, resetOnStop, resetLevelOnClock, syncToClock, gated, randomPhase
- Rewrite LFO component to use Zustand hooks — reads `selectedLfoId` from uiStore, all params from `lfos[lfoId]` in patchStore
- Remove Redux dependency (`useAppSelector`/`selectCurrUiLfoId`) from LFO component
- Add MIDI send/receive following the envelope pattern: sends LFO SELECT CC before params, NRPN for pots, buttons for toggles
- 12 new tests covering LFO MIDI send/receive including LFO selection targeting

## Notes
- LFO stages (curve, toggleStage) and Trigger button MIDI not wired yet — these have complex encoding similar to envelope stages, can be added incrementally
- Pattern matches the envelope MIDI approach: SELECT CC → param NRPN/button
- Rate and Delay pots use `timeResponseMapper` for UI display

## Test plan
- [x] All 165 tests pass, no regressions
- [ ] Verify LFO select button cycles through 1-4
- [ ] Verify Rate/Depth/Balance/Delay pots respond per selected LFO
- [ ] Verify Shape/Sync/Reset/Loop/Invert/Bipolar buttons
- [ ] Verify MIDI send includes LFO select before params
- [ ] Verify MIDI receive targets correct LFO after select

🤖 Generated with [Claude Code](https://claude.com/claude-code)