### PR TITLE
Wire Route panel to Zustand uiStore

### DIFF
--- a/src/components/modules/left2/Route.tsx
+++ b/src/components/modules/left2/Route.tsx
@@ -1,28 +1,31 @@
-import React from 'react';
+import React, { useCallback } from 'react';
 import RotaryPot12 from '../../pots/RotaryPot12';
-import { ControllerGroupIds } from '../../../synthcore/types'
-import { useAppSelector } from '../../../synthcore/hooks'
-import { selectModsUi } from '../../../synthcore/modules/mods/modsReducer'
-import modsControllers from '../../../synthcore/modules/mods/modsControllers'
 import SubHeader from "../../misc/SubHeader";
 import RoundLedPushButton8 from "../../buttons/RoundLedPushButton8";
 import {
     BUTTON_DISTANCE_S,
-    PADDING_LEFT, POT_DISTANCE_L,
+    POT_DISTANCE_L,
     POT_DISTANCE_M,
     POT_OFFSET_Y,
-    ROW_HEIGHT,
-    ROW_SPACING
 } from "../../../constants";
-import { SHOW_CUT } from "../../../config";
 import { ModuleProps } from "../types";
 import { ModuleBorder } from "../../misc/ModuleBorder";
-
-const ctrlGroup = ControllerGroupIds.MODS
+import { useUiStore } from '../../../store/uiStore'
+import { getBounded } from '../../../store/utils'
 
 const Route = ({ x, y, height, width }: ModuleProps) => {
+    const routeButton = useUiStore(s => s.modRouteButton)
+    const setRouteButton = useUiStore(s => s.setModRouteButton)
+    const amount = useUiStore(s => s.modAmount)
+    const setAmount = useUiStore(s => s.setModAmount)
 
-    const route = useAppSelector(selectModsUi)
+    const onRouteClick = useCallback(() => {
+        setRouteButton((routeButton + 1) % 3)
+    }, [routeButton, setRouteButton])
+
+    const onAmountIncrement = useCallback((delta: number) => {
+        setAmount(getBounded(amount + delta, -1, 1))
+    }, [amount, setAmount])
 
     const col1 = x + POT_DISTANCE_M / 2
     const col2 = col1 + BUTTON_DISTANCE_S
@@ -35,23 +38,20 @@ const Route = ({ x, y, height, width }: ModuleProps) => {
 
         <RoundLedPushButton8 labelPosition="bottom-pot" x={col1} y={y + POT_OFFSET_Y} hasOff
                              label="Source"
-                             ctrlGroup={ctrlGroup}
-                             ctrl={modsControllers.ROUTE_BUTTON}
-                             value={route.routeButton}
+                             value={routeButton}
+                             onButtonClick={onRouteClick}
         />
 
         <RoundLedPushButton8 labelPosition="bottom-pot" x={col2} y={y + POT_OFFSET_Y} hasOff
                              label="Dest"
-                             ctrlGroup={ctrlGroup}
-                             ctrl={modsControllers.ROUTE_BUTTON}
-                             value={route.routeButton}
+                             value={routeButton}
+                             onButtonClick={onRouteClick}
         />
 
         <RotaryPot12 ledMode="single" potMode="pan" label="Amount" x={col3}
                      y={y + POT_OFFSET_Y}
-                     ctrlGroup={ctrlGroup}
-                     ctrl={modsControllers.UI_AMOUNT}
-                     value={route.amount}
+                     value={amount}
+                     onValueIncrement={onAmountIncrement}
         />
     </>;
 };

--- a/src/store/uiStore.ts
+++ b/src/store/uiStore.ts
@@ -51,6 +51,8 @@ export interface UiState {
 
     // Modulation routing
     modRouting: ModRoutingSelection
+    modRouteButton: number
+    modAmount: number
 }
 
 export interface UiActions {
@@ -62,6 +64,8 @@ export interface UiActions {
     selectEnvStage: (stageId: StageId) => void
     selectLfo: (lfoId: number) => void
     setModRouting: (routing: Partial<ModRoutingSelection>) => void
+    setModRouteButton: (value: number) => void
+    setModAmount: (value: number) => void
 }
 
 export const useUiStore = create<UiState & UiActions>((set) => ({
@@ -79,6 +83,8 @@ export const useUiStore = create<UiState & UiActions>((set) => ({
         dstFuncId: undefined,
         dstParamId: undefined,
     },
+    modRouteButton: 0,
+    modAmount: 0,
 
     // Actions
     setVoiceGroup: (index) => set({ currentVoiceGroupIndex: index }),
@@ -104,4 +110,8 @@ export const useUiStore = create<UiState & UiActions>((set) => ({
     setModRouting: (routing) => set((state) => ({
         modRouting: { ...state.modRouting, ...routing },
     })),
+
+    setModRouteButton: (value) => set({ modRouteButton: value }),
+
+    setModAmount: (value) => set({ modAmount: value }),
 }))


### PR DESCRIPTION
## Summary
- Add `modRouteButton` and `modAmount` to uiStore (transient UI state for the routing panel)
- Rewrite Route component to read from uiStore instead of Redux (`selectModsUi`)
- Remove Redux dependency (`useAppSelector`) from Route component

## Notes
- This wires the **hardware panel** only (route button + amount pot)
- The actual mod matrix data is already in `ModulationState` in patchStore
- Mod matrix MIDI send/receive, source/destination resolution, and display integration are separate concerns — the old `modsApi.ts` and `modsMidiApi.ts` handle these and can be migrated incrementally
- The amount pot currently shows the uiStore cached value; full integration with the mod matrix (computing amount from `mods[src][dst][index]`) will come when the display screen is wired

## Test plan
- [x] All 153 tests pass, no regressions
- [ ] Verify Route button cycles through Off/From/To
- [ ] Verify Amount pot responds

🤖 Generated with [Claude Code](https://claude.com/claude-code)