### PR TITLE
Wire UI state components to Zustand

### DIFF
--- a/src/components/modules/MainDisplay.tsx
+++ b/src/components/modules/MainDisplay.tsx
@@ -5,14 +5,13 @@ import useEventListener from '../../hooks/useEventListener'
 import RotaryPotWOLeds10 from '../pots/RotaryPotWOLeds10'
 import RoundPushButton8 from '../buttons/RoundPushButton8'
 import RotaryPotWOLeds24 from '../pots/RotaryPotWOLeds24'
-import { ApiSource, ControllerGroupIds } from '../../synthcore/types'
+import { ControllerGroupIds } from '../../synthcore/types'
 import { getPotResolution } from '../../synthcore/modules/mainDisplay/mainDisplayApi'
 import { useAppSelector } from '../../synthcore/hooks'
 import { selectCurrScreen } from '../../synthcore/modules/mainDisplay/mainDisplayReducer'
 import './MainDisplay.scss'
 import mainDisplayControllers from '../../synthcore/modules/mainDisplay/mainDisplayControllers'
-import { dispatch } from '../../synthcore/utils'
-import { click, release } from '../../synthcore/modules/ui/uiReducer'
+import { useUiStore } from '../../store/uiStore'
 import { ModuleProps } from "./types";
 import { BORDER_MARGIN, POT_OFFSET_Y, ROW_HEIGHT } from "../../constants";
 import { displayBG } from "../../config";
@@ -51,22 +50,20 @@ const MainDisplay = React.forwardRef<SVGRectElement, Props>(
         const ctrlSwitchesRow1 = masterPotRow - 10
         const ctrlSwitchesRow2 = masterPotRow + 10
 
+        const setShift = useUiStore(s => s.setShift)
+
         // PC Keyboard handlers
         const handleOnClick = useCallback(({ key }: { key: any }) => {
             if (SHIFT_KEYS.includes(String(key))) {
-                dispatch(click({
-                    ctrlGroup,
-                    ctrl: mainDisplayControllers.FUNC_SHIFT,
-                    source: ApiSource.UI
-                }))
+                setShift(true)
             }
-        }, [])
+        }, [setShift])
 
         const handleOnRelease = useCallback(({ key }: { key: any }) => {
             if (SHIFT_KEYS.includes(String(key))) {
-                dispatch(release({ ctrlGroup, ctrl: mainDisplayControllers.FUNC_SHIFT, source: ApiSource.UI }))
+                setShift(false)
             }
-        }, [])
+        }, [setShift])
 
         useEventListener('keydown', handleOnClick);
         useEventListener('keyup', handleOnRelease);

--- a/src/components/modules/VoiceSelector.tsx
+++ b/src/components/modules/VoiceSelector.tsx
@@ -1,68 +1,36 @@
-import React from 'react';
+import React, { useCallback } from 'react';
 import RoundLedPushButton8 from '../buttons/RoundLedPushButton8';
-import { ControllerGroupIds } from '../../synthcore/types'
-import voicesControllers from '../../synthcore/modules/voices/voicesControllers'
 import { ModuleProps } from "./types";
+import { useUiStore } from '../../store/uiStore'
 
-const ctrlGroup = ControllerGroupIds.VOICES
+const VoiceButton = ({ x, y, index, label }: { x: number, y: number, index: number, label: string }) => {
+    const currentVoiceGroup = useUiStore(s => s.currentVoiceGroupIndex)
+    const setVoiceGroup = useUiStore(s => s.setVoiceGroup)
+
+    const onClick = useCallback(() => {
+        setVoiceGroup(index)
+    }, [setVoiceGroup, index])
+
+    return <RoundLedPushButton8
+        labelPosition="right"
+        x={x}
+        y={y}
+        label={label}
+        value={currentVoiceGroup === index ? 1 : 0}
+        onButtonClick={onClick}
+    />
+}
 
 const VoiceSelector = ({ x, y, width, height }: ModuleProps) => {
     const buttonRow = y
     const buttonDistance = 25;
     const offsetX = x + (width - 7 * buttonDistance) / 2
 
-    //const voices = useAppSelector(selectController(voicesControllers.VOICE))
-
     return <>
-        <RoundLedPushButton8 labelPosition="right" x={offsetX} y={buttonRow} label="1"
-                             ctrlGroup={ctrlGroup}
-                             ctrl={voicesControllers.VOICE}
-                             radioButtonIndex={0}
-        />
-
-        <RoundLedPushButton8 labelPosition="right" x={offsetX + buttonDistance} y={buttonRow} label="2"
-                             ctrlGroup={ctrlGroup}
-                             ctrl={voicesControllers.VOICE}
-                             radioButtonIndex={1}
-        />
-
-        <RoundLedPushButton8 labelPosition="right" x={offsetX + buttonDistance * 2} y={buttonRow} label="3"
-                             ctrlGroup={ctrlGroup}
-                             ctrl={voicesControllers.VOICE}
-                             radioButtonIndex={2}
-        />
-
-        <RoundLedPushButton8 labelPosition="right" x={offsetX + buttonDistance * 3} y={buttonRow} label="4"
-                             ctrlGroup={ctrlGroup}
-                             ctrl={voicesControllers.VOICE}
-                             radioButtonIndex={3}
-        />
-
-        <RoundLedPushButton8 labelPosition="right" x={offsetX + buttonDistance * 4} y={buttonRow} label="5"
-                             ctrlGroup={ctrlGroup}
-                             ctrl={voicesControllers.VOICE}
-                             radioButtonIndex={4}
-        />
-
-        <RoundLedPushButton8 labelPosition="right" x={offsetX + buttonDistance * 5} y={buttonRow} label="6"
-                             ctrlGroup={ctrlGroup}
-                             ctrl={voicesControllers.VOICE}
-                             radioButtonIndex={5}
-        />
-
-        <RoundLedPushButton8 labelPosition="right" x={offsetX + buttonDistance * 6} y={buttonRow} label="7"
-                             ctrlGroup={ctrlGroup}
-                             ctrl={voicesControllers.VOICE}
-                             radioButtonIndex={6}
-        />
-
-        <RoundLedPushButton8 labelPosition="right" x={offsetX + buttonDistance * 7} y={buttonRow} label="8"
-                             ctrlGroup={ctrlGroup}
-                             ctrl={voicesControllers.VOICE}
-                             radioButtonIndex={7}
-        />
-
-    </>;
+        {Array.from({ length: 8 }, (_, i) => (
+            <VoiceButton key={i} x={offsetX + buttonDistance * i} y={buttonRow} index={i} label={`${i + 1}`} />
+        ))}
+    </>
 };
 
 export default VoiceSelector;


### PR DESCRIPTION
## Summary
- Wire left2/LFO.tsx to Zustand (layout variant of left/LFO, same hooks pattern)
- Wire left2/Route.tsx to uiStore (layout variant of left/Route)
- Rewrite VoiceSelector to use uiStore for voice group selection (removes ctrlGroup/ctrl pattern)
- Wire MainDisplay shift key handling to uiStore `setShift` (removes Redux dispatch of click/release actions)
- Add LFO fields used by left2 layout (balance, bipolar, invert, reset, loop) to LfoState
- Add modRouteButton/modAmount to uiStore (for Route panel variants)

## Notes
- MainDisplay still reads `currScreen` from Redux (needed for pot resolution via middleware)
- MainDisplay buttons/pots stay on ctrlGroup/ctrl (screen navigation depends on middleware)
- RightPanel env3Id selector stays on Redux (the env3 select button still uses ctrlGroup/ctrl)
- These will be addressed when the middleware is removed in Phase 4

## Test plan
- [x] All 153 tests pass, no regressions
- [ ] Verify voice selector buttons highlight correct voice group
- [ ] Verify left2 LFO/Route panels respond
- [ ] Verify MainDisplay shift key works (keyboard Shift key)

🤖 Generated with [Claude Code](https://claude.com/claude-code)