### PR TITLE
Remove Redux Provider and eliminate dual-writes

### DIFF
--- a/src/controller/mods/AmountsTable.tsx
+++ b/src/controller/mods/AmountsTable.tsx
@@ -3,8 +3,6 @@ import React, { useCallback, useContext, useEffect, useRef, useState } from 'rea
 import { DraggableElementProps } from './types'
 import { useUiStore } from '../../store/uiStore'
 import { useVoiceGroupStore } from '../../store/patchStore'
-import modsApi from '../../synthcore/modules/mods/modsApi'
-import { ApiSource } from '../../synthcore/types'
 import classNames from 'classnames'
 import AmountBar from './AmountBar'
 import { Point } from '../../utils/types'
@@ -54,9 +52,6 @@ const AmountCell = ({ sourceIndex, funcIndex, funcCtrlIndex, paramIndex, sourceI
                 dstFuncId: funcIndex,
                 dstParamId: paramIndex,
             })
-            modsApi.setGuiSource(sourceIndex, ApiSource.UI)
-            modsApi.setGuiDstFunc(funcIndex, ApiSource.UI)
-            modsApi.setGuiDstParam(paramIndex, ApiSource.UI)
         }
     }, [sourceIndex, funcIndex, paramIndex, clickPos])
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -3,9 +3,9 @@ import ReactDOM from 'react-dom/client';
 import App from './App';
 import * as serviceWorker from './serviceWorker';
 //import './midi/cppControllerConfigGenerator';
-import { Provider } from 'react-redux'
-import { store } from './synthcore/store'
 import midiApi from './midi/midiApi'
+// Import synthcore store to initialize middleware and MIDI receive handlers
+import './synthcore/store'
 import { startEnvelopeMidiSend } from './store/midi/envMidiSend'
 import { startEnvelopeMidiReceive } from './store/midi/envMidiReceive'
 import { startNoiseRingModMidiSend, startNoiseRingModMidiReceive } from './store/midi/noiseRingModMidi'
@@ -49,9 +49,7 @@ const root = ReactDOM.createRoot(
 
 root.render(
     <React.StrictMode>
-        <Provider store={store}>
-            <App/>
-        </Provider>
+        <App/>
     </React.StrictMode>
 );
 

--- a/src/synthcore/hooks.ts
+++ b/src/synthcore/hooks.ts
@@ -1,7 +1,0 @@
-import { TypedUseSelectorHook, useDispatch, useSelector } from 'react-redux'
-import type { RootState, AppDispatch } from './store'
-
-// Use throughout your app instead of plain `useDispatch` and `useSelector`
-export const useAppDispatch = () => useDispatch<AppDispatch>()
-export const useAppSelector: TypedUseSelectorHook<RootState> = useSelector
-

--- a/src/synthcore/modules/mods/modsApi.ts
+++ b/src/synthcore/modules/mods/modsApi.ts
@@ -2,6 +2,8 @@ import { store } from '../../store'
 import midiApi from './modsMidiApi'
 import { ApiSource } from '../../types'
 import { dispatch, getBounded, getQuantized } from '../../utils'
+import { useUiStore } from '../../../store/uiStore'
+import { voiceGroupStores as zustandStores } from '../../../store/patchStore'
 import {
     setGuiSource as setGuiSourceAction,
     setGuiDstGroup as setGuiDstGroupAction,
@@ -114,15 +116,14 @@ const incrementGuiDstParam = (inc: -1 | 1, source: ApiSource) => {
 
 const setModValue = (voiceGroupIndex: number, sourceId: number, dstId: number, dstCtrlIndex: number, modValue: number, source: ApiSource) => {
     const quantizedValue = getQuantized(modValue, 32767)
-    const { voiceGroupStores } = getZustandStores()
 
-    const currModValue = voiceGroupStores[voiceGroupIndex].getState().mods?.[sourceId]?.[dstId]?.[dstCtrlIndex] ?? 0
+    const currModValue = zustandStores[voiceGroupIndex].getState().mods?.[sourceId]?.[dstId]?.[dstCtrlIndex] ?? 0
     if (quantizedValue === currModValue) {
         return
     }
 
     // Write to Zustand store
-    voiceGroupStores[voiceGroupIndex].getState().set((state: any) => {
+    zustandStores[voiceGroupIndex].getState().set((state: any) => {
         if (!state.mods[sourceId]) state.mods[sourceId] = {}
         if (!state.mods[sourceId][dstId]) state.mods[sourceId][dstId] = {}
         state.mods[sourceId][dstId][dstCtrlIndex] = quantizedValue
@@ -137,20 +138,8 @@ const setModValue = (voiceGroupIndex: number, sourceId: number, dstId: number, d
     midiApi.setAmount(voiceGroupIndex, source, modValue)
 }
 
-// Lazy-load to avoid circular dependency: modsApi → synthcoreApi → modsApi
-let _uiStore: any = null
-let _voiceGroupStores: any = null
-function getZustandStores() {
-    if (!_uiStore) {
-        _uiStore = require('../../../store/uiStore').useUiStore
-        _voiceGroupStores = require('../../../store/patchStore').voiceGroupStores
-    }
-    return { uiStore: _uiStore, voiceGroupStores: _voiceGroupStores }
-}
-
 const incrementGuiModValue = (voiceGroupIndex: number, inc: number, source: ApiSource) => {
-    const { uiStore, voiceGroupStores } = getZustandStores()
-    const routing = uiStore.getState().modRouting
+    const routing = useUiStore.getState().modRouting
     const sourceIndex = routing.sourceId ?? 0
     const dstGroupIndex = routing.dstGroupId ?? 0
     const dstFuncIndex = routing.dstFuncId ?? 0
@@ -160,7 +149,7 @@ const incrementGuiModValue = (voiceGroupIndex: number, inc: number, source: ApiS
     const dstId = modDst.dsts[dstGroupIndex][dstFuncIndex][dstParamIndex].id
     const dstCtrlIndex = modDst.funcProps[dstGroupIndex][dstFuncIndex].ctrlIndex || 0
 
-    const currModValue = voiceGroupStores[voiceGroupIndex].getState().mods?.[sourceId]?.[dstId]?.[dstCtrlIndex] ?? 0
+    const currModValue = zustandStores[voiceGroupIndex].getState().mods?.[sourceId]?.[dstId]?.[dstCtrlIndex] ?? 0
     const nextModValue = getBounded(currModValue + inc, -1, 1)
     setModValue(voiceGroupIndex, sourceId, dstId, dstCtrlIndex, nextModValue, source)
 }

--- a/src/synthcore/modules/mods/modsApi.ts
+++ b/src/synthcore/modules/mods/modsApi.ts
@@ -114,12 +114,21 @@ const incrementGuiDstParam = (inc: -1 | 1, source: ApiSource) => {
 
 const setModValue = (voiceGroupIndex: number, sourceId: number, dstId: number, dstCtrlIndex: number, modValue: number, source: ApiSource) => {
     const quantizedValue = getQuantized(modValue, 32767)
-    const currModValue = selectModValue(sourceId, dstId, dstCtrlIndex)(store.getState(), voiceGroupIndex)
+    const { voiceGroupStores } = getZustandStores()
 
+    const currModValue = voiceGroupStores[voiceGroupIndex].getState().mods?.[sourceId]?.[dstId]?.[dstCtrlIndex] ?? 0
     if (quantizedValue === currModValue) {
         return
     }
 
+    // Write to Zustand store
+    voiceGroupStores[voiceGroupIndex].getState().set((state: any) => {
+        if (!state.mods[sourceId]) state.mods[sourceId] = {}
+        if (!state.mods[sourceId][dstId]) state.mods[sourceId][dstId] = {}
+        state.mods[sourceId][dstId][dstCtrlIndex] = quantizedValue
+    })
+
+    // Also dispatch to Redux for any remaining consumers
     dispatch(setModValueAction({ voiceGroupIndex, sourceId, dstId, dstCtrlIndex, modValue: quantizedValue, source }))
 
     // TODO: These should really be converted into ONE!
@@ -128,17 +137,30 @@ const setModValue = (voiceGroupIndex: number, sourceId: number, dstId: number, d
     midiApi.setAmount(voiceGroupIndex, source, modValue)
 }
 
+// Lazy-load to avoid circular dependency: modsApi → synthcoreApi → modsApi
+let _uiStore: any = null
+let _voiceGroupStores: any = null
+function getZustandStores() {
+    if (!_uiStore) {
+        _uiStore = require('../../../store/uiStore').useUiStore
+        _voiceGroupStores = require('../../../store/patchStore').voiceGroupStores
+    }
+    return { uiStore: _uiStore, voiceGroupStores: _voiceGroupStores }
+}
+
 const incrementGuiModValue = (voiceGroupIndex: number, inc: number, source: ApiSource) => {
-    const sourceIndex = selectGuiSource(store.getState())
-    const dstGroupIndex = selectGuiDstGroup(store.getState())
-    const dstFuncIndex = selectGuiDstFunc(store.getState())
-    const dstParamIndex = selectGuiDstParam(store.getState())
+    const { uiStore, voiceGroupStores } = getZustandStores()
+    const routing = uiStore.getState().modRouting
+    const sourceIndex = routing.sourceId ?? 0
+    const dstGroupIndex = routing.dstGroupId ?? 0
+    const dstFuncIndex = routing.dstFuncId ?? 0
+    const dstParamIndex = routing.dstParamId ?? 0
 
     const sourceId = digitalModSources[sourceIndex].id
     const dstId = modDst.dsts[dstGroupIndex][dstFuncIndex][dstParamIndex].id
     const dstCtrlIndex = modDst.funcProps[dstGroupIndex][dstFuncIndex].ctrlIndex || 0
 
-    const currModValue = selectModValue(sourceId, dstId, dstCtrlIndex)(store.getState(), voiceGroupIndex)
+    const currModValue = voiceGroupStores[voiceGroupIndex].getState().mods?.[sourceId]?.[dstId]?.[dstCtrlIndex] ?? 0
     const nextModValue = getBounded(currModValue + inc, -1, 1)
     setModValue(voiceGroupIndex, sourceId, dstId, dstCtrlIndex, nextModValue, source)
 }

--- a/src/synthcore/modules/mods/modsMainDisplayApi.ts
+++ b/src/synthcore/modules/mods/modsMainDisplayApi.ts
@@ -1,9 +1,8 @@
 import { useUiStore, ModRoutingSelection } from '../../../store/uiStore'
-import { voiceGroupStores } from '../../../store/patchStore'
 import { step } from '../../utils'
 import mainDisplayControllers from '../mainDisplay/mainDisplayControllers'
 import { digitalModSources, modDst } from './utils'
-import { getBounded, getQuantized } from '../../../store/utils'
+import { getBounded } from '../../../store/utils'
 import modsApi from './modsApi'
 import { ApiSource } from '../../types'
 
@@ -17,16 +16,8 @@ export const mainDisplayModsPotResolutions = {
     [mainDisplayControllers.POT7.id]: 1000,
 }
 
-// Dual-write selection to both uiStore and Redux so display and modsApi stay in sync
 function setRouting(changes: Partial<ModRoutingSelection>) {
     useUiStore.getState().setModRouting(changes)
-
-    // Sync full state to Redux after applying changes
-    const routing = useUiStore.getState().modRouting
-    modsApi.setGuiSource(routing.sourceId ?? 0, ApiSource.UI)
-    modsApi.setGuiDstGroup(routing.dstGroupId ?? 0, ApiSource.UI)
-    modsApi.setGuiDstFunc(routing.dstFuncId ?? 0, ApiSource.UI)
-    modsApi.setGuiDstParam(routing.dstParamId ?? 0, ApiSource.UI)
 }
 
 export const mainDisplayModsApi = {
@@ -86,21 +77,6 @@ export const mainDisplayModsApi = {
             }
 
         } else if (ctrlId === mainDisplayControllers.POT5.id) {
-            const sourceId = digitalModSources[sourceIndex].id
-            const dstId = modDst.dsts[dstGroupIndex][dstFuncIndex][dstParamIndex].id
-            const dstCtrlIndex = modDst.funcProps[dstGroupIndex][dstFuncIndex].ctrlIndex || 0
-
-            // Read current value from Zustand, increment, write to both Zustand and Redux+MIDI
-            const store = voiceGroupStores[voiceGroupIndex].getState()
-            const currValue = store.mods?.[sourceId]?.[dstId]?.[dstCtrlIndex] ?? 0
-            const nextValue = getQuantized(getBounded(currValue + increment, -1, 1), 32767)
-
-            voiceGroupStores[voiceGroupIndex].getState().set(state => {
-                if (!state.mods[sourceId]) state.mods[sourceId] = {}
-                if (!state.mods[sourceId][dstId]) state.mods[sourceId][dstId] = {}
-                state.mods[sourceId][dstId][dstCtrlIndex] = nextValue
-            })
-
             modsApi.incrementGuiModValue(voiceGroupIndex, increment, ApiSource.UI)
 
         } else if (ctrlId === mainDisplayControllers.POT6.id) {


### PR DESCRIPTION
## Summary
- Remove Redux `<Provider>` wrapper from index.tsx — no React component uses Redux hooks
- Delete `synthcore/hooks.ts` (`useAppSelector`/`useAppDispatch`) — unused
- `modsApi` reads selection from uiStore and mod values from voiceGroupStores instead of Redux
- `modsApi.setModValue` writes to Zustand stores directly (+ Redux for remaining internal consumers)
- Simplified `modsMainDisplayApi` — no more Redux sync needed
- Simplified `AmountsTable` cell click — only writes to uiStore
- `react-redux` is no longer imported anywhere in `src/`

## What's left
Redux store + middleware still exist in `src/synthcore/` for:
- `mainDisplayApi` screen routing (reads from Redux)
- `lfoApi` internal state management
- MIDI receive handlers in `mainDisplayMidiApi`
- `VoiceSelector` dual-write dispatch

## Test plan
- [x] All 240 tests pass
- [x] No new TypeScript errors
- [ ] Verify mods amount changes work across voice groups
- [ ] Verify mod cell selection works in display

🤖 Generated with [Claude Code](https://claude.com/claude-code)