### PR TITLE
Convert mainDisplayApi to uiStore, remove last Redux from UI

### DIFF
--- a/src/components/modules/MainDisplay.tsx
+++ b/src/components/modules/MainDisplay.tsx
@@ -58,7 +58,6 @@ const MainDisplay = React.forwardRef<SVGRectElement, Props>(
 
         const currentScreen = useUiStore(s => s.currentScreen)
         const setScreen = useUiStore(s => s.setScreen)
-        const setShift = useUiStore(s => s.setShift)
         const voiceGroupIndex = useUiStore(s => s.currentVoiceGroupIndex)
 
         const currScreenNumeric = screenIdToMainDisplayScreenId[currentScreen] ?? MainDisplayScreenId.ENV
@@ -129,20 +128,18 @@ const MainDisplay = React.forwardRef<SVGRectElement, Props>(
             mainDisplayApi.handleRouteClick(ApiSource.UI)
         }, [])
 
-        // PC Keyboard handlers - dual-write to both uiStore and Redux
+        // PC Keyboard handlers
         const handleOnClick = useCallback(({ key }: { key: any }) => {
             if (SHIFT_KEYS.includes(String(key))) {
-                setShift(true)
                 mainDisplayApi.handleShift(true, ApiSource.UI)
             }
-        }, [setShift])
+        }, [])
 
         const handleOnRelease = useCallback(({ key }: { key: any }) => {
             if (SHIFT_KEYS.includes(String(key))) {
-                setShift(false)
                 mainDisplayApi.handleShift(false, ApiSource.UI)
             }
-        }, [setShift])
+        }, [])
 
         useEventListener('keydown', handleOnClick);
         useEventListener('keyup', handleOnRelease);

--- a/src/components/modules/MainDisplay.tsx
+++ b/src/components/modules/MainDisplay.tsx
@@ -13,7 +13,6 @@ import { ModuleProps } from "./types";
 import { BORDER_MARGIN, POT_OFFSET_Y, ROW_HEIGHT } from "../../constants";
 import mainDisplayApi from '../../synthcore/modules/mainDisplay/mainDisplayApi'
 import { ApiSource } from '../../synthcore/types'
-import { MainDisplayScreenId } from '../../synthcore/modules/mainDisplay/types'
 
 const SHIFT_KEYS = ['16', 'Shift'];
 
@@ -37,17 +36,6 @@ const screenToMenuIndex: Partial<Record<ScreenId, number>> = {
     [ScreenId.FX]: 5,
 }
 
-// Map uiStore ScreenId to old MainDisplayScreenId for pot resolution lookup
-const screenIdToMainDisplayScreenId: Partial<Record<ScreenId, MainDisplayScreenId>> = {
-    [ScreenId.LFO]: MainDisplayScreenId.LFO,
-    [ScreenId.OSC]: MainDisplayScreenId.OSC,
-    [ScreenId.FILTER]: MainDisplayScreenId.FILTER,
-    [ScreenId.ENV]: MainDisplayScreenId.ENV,
-    [ScreenId.MOD]: MainDisplayScreenId.MOD,
-    [ScreenId.FX]: MainDisplayScreenId.FX,
-    [ScreenId.SETTINGS]: MainDisplayScreenId.SETTINGS,
-}
-
 type Props = ModuleProps & {
     panelHeight: number
 }
@@ -60,7 +48,6 @@ const MainDisplay = React.forwardRef<SVGRectElement, Props>(
         const setScreen = useUiStore(s => s.setScreen)
         const voiceGroupIndex = useUiStore(s => s.currentVoiceGroupIndex)
 
-        const currScreenNumeric = screenIdToMainDisplayScreenId[currentScreen] ?? MainDisplayScreenId.ENV
         const menuIndex = screenToMenuIndex[currentScreen] ?? -1
 
         // approx. 9"
@@ -189,36 +176,36 @@ const MainDisplay = React.forwardRef<SVGRectElement, Props>(
             <RotaryPotWOLeds10 x={displayCenterX - 2.5 * potSpacing} y={potRow}
                                silver
                                onValueIncrement={makePotIncrement(0)}
-                               resolution={getPotResolution(mainDisplayControllers.POT1.id, currScreenNumeric)}
+                               resolution={getPotResolution(mainDisplayControllers.POT1.id, currentScreen)}
             />
             <RotaryPotWOLeds10 x={displayCenterX - 1.5 * potSpacing} y={potRow}
                                silver
                                onValueIncrement={makePotIncrement(1)}
-                               resolution={getPotResolution(mainDisplayControllers.POT2.id, currScreenNumeric)}
+                               resolution={getPotResolution(mainDisplayControllers.POT2.id, currentScreen)}
             />
             <RotaryPotWOLeds10 x={displayCenterX - 0.5 * potSpacing} y={potRow}
                                silver
                                onValueIncrement={makePotIncrement(2)}
-                               resolution={getPotResolution(mainDisplayControllers.POT3.id, currScreenNumeric)}
+                               resolution={getPotResolution(mainDisplayControllers.POT3.id, currentScreen)}
             />
             <RotaryPotWOLeds10 x={displayCenterX + 0.5 * potSpacing} y={potRow}
                                silver
                                onValueIncrement={makePotIncrement(3)}
-                               resolution={getPotResolution(mainDisplayControllers.POT4.id, currScreenNumeric)}
+                               resolution={getPotResolution(mainDisplayControllers.POT4.id, currentScreen)}
             />
             <RotaryPotWOLeds10 x={displayCenterX + 1.5 * potSpacing} y={potRow}
                                silver
                                onValueIncrement={makePotIncrement(4)}
-                               resolution={getPotResolution(mainDisplayControllers.POT5.id, currScreenNumeric)}
+                               resolution={getPotResolution(mainDisplayControllers.POT5.id, currentScreen)}
             />
             <RotaryPotWOLeds10 x={displayCenterX + 2.5 * potSpacing} y={potRow}
                                silver
                                onValueIncrement={makePotIncrement(5)}
-                               resolution={getPotResolution(mainDisplayControllers.POT6.id, currScreenNumeric)}
+                               resolution={getPotResolution(mainDisplayControllers.POT6.id, currentScreen)}
             />
             <RotaryPotWOLeds24 x={displayCenterX} y={masterPotRow}
                                onValueIncrement={makePotIncrement(6)}
-                               resolution={getPotResolution(mainDisplayControllers.POT7.id, currScreenNumeric)}
+                               resolution={getPotResolution(mainDisplayControllers.POT7.id, currentScreen)}
             />
 
             <RoundPushButton8 x={displayCenterX - 2.5 * buttonSpacing} y={ctrlSwitchesRow1} label="Home"

--- a/src/components/modules/VoiceSelector.tsx
+++ b/src/components/modules/VoiceSelector.tsx
@@ -3,9 +3,6 @@ import RoundLedPushButton8 from '../buttons/RoundLedPushButton8';
 import { ModuleProps } from "./types";
 import { useUiStore } from '../../store/uiStore'
 import { setVoiceGroupIndex } from '../../synthcore/modules/voices/currentVoiceGroupIndex'
-import voicesControllers from '../../synthcore/modules/voices/voicesControllers'
-import { setController } from '../../synthcore/modules/controllers/controllersReducer'
-import { dispatch } from '../../synthcore/utils'
 
 const VoiceButton = ({ x, y, index, label }: { x: number, y: number, index: number, label: string }) => {
     const currentVoiceGroup = useUiStore(s => s.currentVoiceGroupIndex)
@@ -14,12 +11,6 @@ const VoiceButton = ({ x, y, index, label }: { x: number, y: number, index: numb
     const onClick = useCallback(() => {
         setVoiceGroup(index)
         setVoiceGroupIndex(index)
-        // Dispatch to Redux so display components re-render
-        dispatch(setController({
-            ctrl: voicesControllers.VOICE,
-            value: index,
-            voiceGroupIndex: index,
-        }))
     }, [setVoiceGroup, index])
 
     return <RoundLedPushButton8

--- a/src/synthcore/modules/mainDisplay/mainDisplayApi.ts
+++ b/src/synthcore/modules/mainDisplay/mainDisplayApi.ts
@@ -1,4 +1,3 @@
-import { MainDisplayScreenId } from './types'
 import { mainDisplayModsApi, mainDisplayModsPotResolutions } from '../mods/modsMainDisplayApi'
 import { mainDisplayEnvApi, mainDisplayEnvPotResolutions } from '../env/envMainDisplayApi'
 import mainDisplayMidiApi from './mainDisplayMidiApi'
@@ -11,35 +10,24 @@ import { useUiStore, ScreenId } from '../../../store/uiStore'
 
 
 type PotResolutions = {
-    [key: number]: {
+    [key: string]: {
         [key: number]: number
     }
 }
 
 const potResolution: PotResolutions = {
-    [MainDisplayScreenId.ENV]: mainDisplayEnvPotResolutions,
-    [MainDisplayScreenId.LFO]: mainDisplayLfoPotResolutions,
-    [MainDisplayScreenId.MOD]: mainDisplayModsPotResolutions,
-    [MainDisplayScreenId.SETTINGS]: mainDisplaySettingsPotResolutions,
+    [ScreenId.ENV]: mainDisplayEnvPotResolutions,
+    [ScreenId.LFO]: mainDisplayLfoPotResolutions,
+    [ScreenId.MOD]: mainDisplayModsPotResolutions,
+    [ScreenId.SETTINGS]: mainDisplaySettingsPotResolutions,
 }
 
-export const getPotResolution = (ctrlId: number, currScreen: number) => {
+export const getPotResolution = (ctrlId: number, currScreen: ScreenId) => {
     const screenPots = potResolution[currScreen]
     if (screenPots?.[ctrlId]) {
         return screenPots[ctrlId]
     }
     return 1000
-}
-
-// Map ScreenId string values to MainDisplayScreenId numbers
-const screenToNumeric: Record<string, MainDisplayScreenId> = {
-    [ScreenId.LFO]: MainDisplayScreenId.LFO,
-    [ScreenId.OSC]: MainDisplayScreenId.OSC,
-    [ScreenId.FILTER]: MainDisplayScreenId.FILTER,
-    [ScreenId.ENV]: MainDisplayScreenId.ENV,
-    [ScreenId.MOD]: MainDisplayScreenId.MOD,
-    [ScreenId.FX]: MainDisplayScreenId.FX,
-    [ScreenId.SETTINGS]: MainDisplayScreenId.SETTINGS,
 }
 
 const handleHomeClick = (source: ApiSource) => {
@@ -71,15 +59,14 @@ const handleRouteClick = (source: ApiSource) => {
 
 const handleMainDisplayController = (voiceGroupIndex: number, ctrlId: number, value: number, source: ApiSource) => {
     const currentScreen = useUiStore.getState().currentScreen
-    const currScreenId = screenToNumeric[currentScreen]
 
-    if (currScreenId === MainDisplayScreenId.MOD) {
+    if (currentScreen === ScreenId.MOD) {
         mainDisplayModsApi.handleMainDisplayController(voiceGroupIndex, ctrlId, value)
-    } else if (currScreenId === MainDisplayScreenId.ENV) {
+    } else if (currentScreen === ScreenId.ENV) {
         mainDisplayEnvApi.handleMainDisplayController(voiceGroupIndex, ctrlId, value)
-    } else if (currScreenId === MainDisplayScreenId.LFO) {
+    } else if (currentScreen === ScreenId.LFO) {
         mainDisplayLfoApi.handleMainDisplayController(voiceGroupIndex, ctrlId, value)
-    } else if (currScreenId === MainDisplayScreenId.SETTINGS) {
+    } else if (currentScreen === ScreenId.SETTINGS) {
         mainDisplaySettingsApi.handleMainDisplayController(voiceGroupIndex, ctrlId, value)
     }
 

--- a/src/synthcore/modules/mainDisplay/mainDisplayApi.ts
+++ b/src/synthcore/modules/mainDisplay/mainDisplayApi.ts
@@ -1,12 +1,4 @@
 import { MainDisplayScreenId } from './types'
-import { store } from '../../store'
-import {
-    selectCurrScreen,
-    setCurrentScreen as setCurrentScreenAction,
-    setPreviousScreen as setPreviousScreenAction,
-    setShiftOn
-} from './mainDisplayReducer'
-import { dispatch } from '../../utils'
 import { mainDisplayModsApi, mainDisplayModsPotResolutions } from '../mods/modsMainDisplayApi'
 import { mainDisplayEnvApi, mainDisplayEnvPotResolutions } from '../env/envMainDisplayApi'
 import mainDisplayMidiApi from './mainDisplayMidiApi'
@@ -15,6 +7,7 @@ import mainDisplayControllers from './mainDisplayControllers'
 import { createClickMapper, createIncrementMapper } from '../common/utils'
 import { mainDisplaySettingsApi, mainDisplaySettingsPotResolutions } from '../settings/settingsMainDisplayApi'
 import { mainDisplayLfoApi, mainDisplayLfoPotResolutions } from '../lfo/lfoMainDisplayApi'
+import { useUiStore, ScreenId } from '../../../store/uiStore'
 
 
 type PotResolutions = {
@@ -22,13 +15,6 @@ type PotResolutions = {
         [key: number]: number
     }
 }
-
-// Screens that should not be pushed to 'previousScreen', they are modals that should revert to previous screen
-// BEFORE any modal.
-const modalScreens = [
-    MainDisplayScreenId.SAVE,
-    MainDisplayScreenId.LOAD,
-]
 
 const potResolution: PotResolutions = {
     [MainDisplayScreenId.ENV]: mainDisplayEnvPotResolutions,
@@ -45,6 +31,17 @@ export const getPotResolution = (ctrlId: number, currScreen: number) => {
     return 1000
 }
 
+// Map ScreenId string values to MainDisplayScreenId numbers
+const screenToNumeric: Record<string, MainDisplayScreenId> = {
+    [ScreenId.LFO]: MainDisplayScreenId.LFO,
+    [ScreenId.OSC]: MainDisplayScreenId.OSC,
+    [ScreenId.FILTER]: MainDisplayScreenId.FILTER,
+    [ScreenId.ENV]: MainDisplayScreenId.ENV,
+    [ScreenId.MOD]: MainDisplayScreenId.MOD,
+    [ScreenId.FX]: MainDisplayScreenId.FX,
+    [ScreenId.SETTINGS]: MainDisplayScreenId.SETTINGS,
+}
+
 const handleHomeClick = (source: ApiSource) => {
     mainDisplayMidiApi.homeClick(source)
 }
@@ -52,7 +49,7 @@ const handleSettingsClick = (source: ApiSource) => {
     mainDisplayMidiApi.settingsClick(source)
 }
 const handleShift = (on: boolean, source: ApiSource) => {
-    dispatch(setShiftOn({ voiceGroupIndex: -1, value: on }))
+    useUiStore.getState().setShift(on)
     mainDisplayMidiApi.shift(source, on)
 }
 const handlePerformClick = (source: ApiSource) => {
@@ -60,12 +57,10 @@ const handlePerformClick = (source: ApiSource) => {
 }
 const handleLoadClick = (source: ApiSource) => {
     mainDisplayMidiApi.loadClick(source)
-    //patchStorageApi.loadPatch()
 }
 const handleSaveClick = (source: ApiSource) => {
     console.log(`Save form ${source}`)
     mainDisplayMidiApi.saveClick(source)
-    //patchStorageApi.savePatch()
 }
 const handleCompareClick = (source: ApiSource) => {
     mainDisplayMidiApi.compareClick(source)
@@ -75,7 +70,9 @@ const handleRouteClick = (source: ApiSource) => {
 }
 
 const handleMainDisplayController = (voiceGroupIndex: number, ctrlId: number, value: number, source: ApiSource) => {
-    const currScreenId = selectCurrScreen(store.getState())
+    const currentScreen = useUiStore.getState().currentScreen
+    const currScreenId = screenToNumeric[currentScreen]
+
     if (currScreenId === MainDisplayScreenId.MOD) {
         mainDisplayModsApi.handleMainDisplayController(voiceGroupIndex, ctrlId, value)
     } else if (currScreenId === MainDisplayScreenId.ENV) {
@@ -92,11 +89,6 @@ const handleMainDisplayController = (voiceGroupIndex: number, ctrlId: number, va
 }
 
 const setCurrentScreen = (id: number, source: ApiSource) => {
-    const currentId = selectCurrScreen(store.getState())
-    if (!modalScreens.includes(currentId)) {
-        dispatch(setPreviousScreenAction({ id: currentId }))
-    }
-    dispatch(setCurrentScreenAction({ id }))
     mainDisplayMidiApi.setCurrentScreen(source, id)
 }
 


### PR DESCRIPTION
## Summary
- `mainDisplayApi` reads screen from uiStore instead of Redux `selectCurrScreen(store.getState())`
- `mainDisplayApi.handleShift` writes to uiStore directly
- MainDisplay keyboard shift simplified — no more dual-write
- VoiceSelector removed Redux `dispatch(setController(...))` — no component uses `useAppSelector` anymore
- **Zero Redux imports remain in `src/components/` and `src/controller/`**

## Redux status
Redux store and middleware still exist in `src/synthcore/` as internal plumbing for:
- MIDI receive handlers in various midiApi files
- ControllerHandler classes for value validation
- Patch storage operations

These are not visible to any React component and can be removed in a future phase.

## Test plan
- [x] All 240 tests pass
- [x] No new TypeScript errors
- [ ] Verify screen selection and pot routing works
- [ ] Verify voice group switching works
- [ ] Verify shift key works for LFO display

🤖 Generated with [Claude Code](https://claude.com/claude-code)