### PR TITLE
Remove @reduxjs/toolkit and react-redux dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,6 @@
       "name": "synth-gui-react",
       "version": "0.1.0",
       "dependencies": {
-        "@reduxjs/toolkit": "^1.9.7",
         "@types/react-slider": "^1.3.5",
         "@types/webmidi": "^2.0.8",
         "@use-it/event-listener": "^0.1.7",
@@ -21,7 +20,6 @@
         "react-dnd-html5-backend": "^16.0.1",
         "react-dom": "^18.2.0",
         "react-keyed-file-browser": "^1.14.0",
-        "react-redux": "^8.1.3",
         "react-simple-keyboard": "^3.7.110",
         "react-slider": "^2.0.6",
         "react-spring": "^9.7.3",
@@ -1416,40 +1414,6 @@
         "zdog": ">=1.0"
       }
     },
-    "node_modules/@reduxjs/toolkit": {
-      "version": "1.9.7",
-      "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-1.9.7.tgz",
-      "integrity": "sha512-t7v8ZPxhhKgOKtU+uyJT13lu4vL7az5aFi4IdoDs/eS548edn2M8Ik9h8fxgvMjGoAUVFSt6ZC1P5cWmQ014QQ==",
-      "license": "MIT",
-      "dependencies": {
-        "immer": "^9.0.21",
-        "redux": "^4.2.1",
-        "redux-thunk": "^2.4.2",
-        "reselect": "^4.1.8"
-      },
-      "peerDependencies": {
-        "react": "^16.9.0 || ^17.0.0 || ^18",
-        "react-redux": "^7.2.1 || ^8.0.2"
-      },
-      "peerDependenciesMeta": {
-        "react": {
-          "optional": true
-        },
-        "react-redux": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@reduxjs/toolkit/node_modules/immer": {
-      "version": "9.0.21",
-      "resolved": "https://registry.npmjs.org/immer/-/immer-9.0.21.tgz",
-      "integrity": "sha512-bc4NBHqOqSfRW7POMkHd51LvClaeMXpm8dx0e8oE2GORbq5aRK7Bxl4FyzVLdGtLmvLKL7BTDBG5ACQm4HWjTA==",
-      "license": "MIT",
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/immer"
-      }
-    },
     "node_modules/@rolldown/binding-android-arm64": {
       "version": "1.0.0-rc.10",
       "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0-rc.10.tgz",
@@ -2154,6 +2118,7 @@
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/@types/hoist-non-react-statics/-/hoist-non-react-statics-3.3.1.tgz",
       "integrity": "sha512-iMIqiko6ooLrTh1joXodJK5X9xeEALT1kM5G3ZLhD3hszxBdIEd5C75U834D9mLcINgD4OyZf5uQXjkuYydWvA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/react": "*",
@@ -2228,12 +2193,6 @@
       "version": "4.2.7",
       "resolved": "https://registry.npmjs.org/@types/stylis/-/stylis-4.2.7.tgz",
       "integrity": "sha512-VgDNokpBoKF+wrdvhAAfS55OMQpL6QRglwTwNC3kIgBrzZxA4WsFj+2eLfEA/uMUDzBcEhYmjSbwQakn/i3ajA==",
-      "license": "MIT"
-    },
-    "node_modules/@types/use-sync-external-store": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.3.tgz",
-      "integrity": "sha512-EwmlvuaxPNej9+T4v5AuBPJa2x2UOJVdjCtDHgcDqitUeOtjnJKJ+apYjVcAoBEMjKW1VVFGZLUb5+qqa09XFA==",
       "license": "MIT"
     },
     "node_modules/@types/webmidi": {
@@ -3847,51 +3806,6 @@
         "dnd-core": "14.0.1"
       }
     },
-    "node_modules/react-redux": {
-      "version": "8.1.3",
-      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-8.1.3.tgz",
-      "integrity": "sha512-n0ZrutD7DaX/j9VscF+uTALI3oUPa/pO4Z3soOBIjuRn/FzVu6aehhysxZCLi6y7duMf52WNZGMl7CtuK5EnRw==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.12.1",
-        "@types/hoist-non-react-statics": "^3.3.1",
-        "@types/use-sync-external-store": "^0.0.3",
-        "hoist-non-react-statics": "^3.3.2",
-        "react-is": "^18.0.0",
-        "use-sync-external-store": "^1.0.0"
-      },
-      "peerDependencies": {
-        "@types/react": "^16.8 || ^17.0 || ^18.0",
-        "@types/react-dom": "^16.8 || ^17.0 || ^18.0",
-        "react": "^16.8 || ^17.0 || ^18.0",
-        "react-dom": "^16.8 || ^17.0 || ^18.0",
-        "react-native": ">=0.59",
-        "redux": "^4 || ^5.0.0-beta.0"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        },
-        "@types/react-dom": {
-          "optional": true
-        },
-        "react-dom": {
-          "optional": true
-        },
-        "react-native": {
-          "optional": true
-        },
-        "redux": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/react-redux/node_modules/react-is": {
-      "version": "18.3.1",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
-      "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
-      "license": "MIT"
-    },
     "node_modules/react-refresh": {
       "version": "0.17.0",
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.17.0.tgz",
@@ -3964,25 +3878,10 @@
         "@babel/runtime": "^7.9.2"
       }
     },
-    "node_modules/redux-thunk": {
-      "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-2.4.2.tgz",
-      "integrity": "sha512-+P3TjtnP0k/FEjcBL5FZpoovtvrTNT/UXd4/sluaSyrURlSlhLSzEdfsTBW7WsKB6yPvgd7q/iZPICFjW4o57Q==",
-      "license": "MIT",
-      "peerDependencies": {
-        "redux": "^4"
-      }
-    },
     "node_modules/regenerator-runtime": {
       "version": "0.13.11",
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
       "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==",
-      "license": "MIT"
-    },
-    "node_modules/reselect": {
-      "version": "4.1.8",
-      "resolved": "https://registry.npmjs.org/reselect/-/reselect-4.1.8.tgz",
-      "integrity": "sha512-ab9EmR80F/zQTMNeneUr4cv+jSwPJgIlvEmVwLerwrWVbpLlBuls9XHzIeTFy4cegU2NHBp3va0LKOzU5qFEYQ==",
       "license": "MIT"
     },
     "node_modules/resolve-pkg-maps": {
@@ -4422,15 +4321,6 @@
       },
       "peerDependencies": {
         "browserslist": ">= 4.21.0"
-      }
-    },
-    "node_modules/use-sync-external-store": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
-      "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
-      "license": "MIT",
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/vite": {

--- a/package.json
+++ b/package.json
@@ -5,7 +5,6 @@
   "homepage": "http://xonik.no/synth-gui-react",
   "type": "module",
   "dependencies": {
-    "@reduxjs/toolkit": "^1.9.7",
     "@types/react-slider": "^1.3.5",
     "@types/webmidi": "^2.0.8",
     "@use-it/event-listener": "^0.1.7",
@@ -18,7 +17,6 @@
     "react-dnd-html5-backend": "^16.0.1",
     "react-dom": "^18.2.0",
     "react-keyed-file-browser": "^1.14.0",
-    "react-redux": "^8.1.3",
     "react-simple-keyboard": "^3.7.110",
     "react-slider": "^2.0.6",
     "react-spring": "^9.7.3",


### PR DESCRIPTION
## Summary
Remove `@reduxjs/toolkit` and `react-redux` from package.json. No code imports these packages anymore. 8 npm packages removed.

This is the final step of the Redux → Zustand migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)